### PR TITLE
Use handlebars >= 4.0.0

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -2,6 +2,7 @@
   "name": "client",
   "version": "0.0.0",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "@angular/animations": {
       "version": "4.1.3",
@@ -12,7 +13,67 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-1.1.0.tgz",
       "integrity": "sha1-zmhozvOeaUqEqePr+4At6BxGO70=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "@ngtools/json-schema": "1.1.0",
+        "@ngtools/webpack": "1.4.0",
+        "autoprefixer": "6.7.7",
+        "chalk": "1.1.3",
+        "common-tags": "1.4.0",
+        "css-loader": "0.28.4",
+        "cssnano": "3.10.0",
+        "debug": "2.6.8",
+        "denodeify": "1.2.1",
+        "diff": "3.2.0",
+        "ember-cli-normalize-entity-name": "1.0.0",
+        "ember-cli-string-utils": "1.1.0",
+        "exports-loader": "0.6.4",
+        "extract-text-webpack-plugin": "2.1.0",
+        "file-loader": "0.10.1",
+        "fs-extra": "2.1.2",
+        "get-caller-file": "1.0.2",
+        "glob": "7.1.2",
+        "html-webpack-plugin": "2.28.0",
+        "inflection": "1.12.0",
+        "inquirer": "3.0.6",
+        "isbinaryfile": "3.0.2",
+        "istanbul-instrumenter-loader": "2.0.0",
+        "json-loader": "0.5.4",
+        "less": "2.7.2",
+        "less-loader": "4.0.4",
+        "lodash": "4.17.4",
+        "memory-fs": "0.4.1",
+        "minimatch": "3.0.4",
+        "node-modules-path": "1.0.1",
+        "node-sass": "4.5.3",
+        "nopt": "4.0.1",
+        "opn": "4.0.2",
+        "portfinder": "1.0.13",
+        "postcss-loader": "1.3.3",
+        "postcss-url": "5.1.2",
+        "raw-loader": "0.5.1",
+        "resolve": "1.3.3",
+        "rimraf": "2.6.1",
+        "rsvp": "3.5.0",
+        "rxjs": "5.4.0",
+        "sass-loader": "6.0.5",
+        "script-loader": "0.7.0",
+        "semver": "5.3.0",
+        "silent-error": "1.1.0",
+        "source-map-loader": "0.2.1",
+        "style-loader": "0.13.2",
+        "stylus": "0.54.5",
+        "stylus-loader": "3.0.1",
+        "temp": "0.8.3",
+        "typescript": "2.3.4",
+        "url-loader": "0.5.8",
+        "walk-sync": "0.3.2",
+        "webpack": "2.4.1",
+        "webpack-dev-middleware": "1.10.2",
+        "webpack-dev-server": "2.4.5",
+        "webpack-merge": "2.6.1",
+        "zone.js": "0.8.11"
+      }
     },
     "@angular/common": {
       "version": "4.1.3",
@@ -27,7 +88,12 @@
     "@angular/compiler-cli": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-4.1.3.tgz",
-      "integrity": "sha1-wjYv/fZXVkcUgfg5+rZ1vKwhP5Y="
+      "integrity": "sha1-wjYv/fZXVkcUgfg5+rZ1vKwhP5Y=",
+      "requires": {
+        "@angular/tsc-wrapped": "4.1.3",
+        "minimist": "1.2.0",
+        "reflect-metadata": "0.1.10"
+      }
     },
     "@angular/core": {
       "version": "4.1.3",
@@ -57,7 +123,11 @@
     "@angular/platform-server": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/@angular/platform-server/-/platform-server-4.1.3.tgz",
-      "integrity": "sha1-u/rkKxVzA1d1HaDhRdaG+SWpRDE="
+      "integrity": "sha1-u/rkKxVzA1d1HaDhRdaG+SWpRDE=",
+      "requires": {
+        "parse5": "3.0.2",
+        "xhr2": "0.1.4"
+      }
     },
     "@angular/router": {
       "version": "4.1.3",
@@ -67,7 +137,10 @@
     "@angular/tsc-wrapped": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/@angular/tsc-wrapped/-/tsc-wrapped-4.1.3.tgz",
-      "integrity": "sha1-LWNyyRh78WIerNlguUs5xPlSk80="
+      "integrity": "sha1-LWNyyRh78WIerNlguUs5xPlSk80=",
+      "requires": {
+        "tsickle": "0.21.6"
+      }
     },
     "@ngtools/json-schema": {
       "version": "1.1.0",
@@ -79,7 +152,13 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-1.4.0.tgz",
       "integrity": "sha1-3OisfpWel73+WDtcNV18mTUhTvo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "enhanced-resolve": "3.1.0",
+        "loader-utils": "1.1.0",
+        "magic-string": "0.19.1",
+        "source-map": "0.5.6"
+      }
     },
     "@types/autolinker": {
       "version": "0.24.28",
@@ -119,7 +198,11 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
       "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "mime-types": "2.1.15",
+        "negotiator": "0.6.1"
+      }
     },
     "acorn": {
       "version": "5.0.3",
@@ -132,6 +215,9 @@
       "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
       "integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
       "dev": true,
+      "requires": {
+        "acorn": "4.0.13"
+      },
       "dependencies": {
         "acorn": {
           "version": "4.0.13",
@@ -158,6 +244,10 @@
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
       "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
       "dev": true,
+      "requires": {
+        "extend": "3.0.1",
+        "semver": "5.0.3"
+      },
       "dependencies": {
         "semver": {
           "version": "5.0.3",
@@ -171,7 +261,11 @@
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
       "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "co": "4.6.0",
+        "json-stable-stringify": "1.0.1"
+      }
     },
     "ajv-keywords": {
       "version": "1.5.1",
@@ -183,7 +277,12 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2",
+        "longest": "1.0.1",
+        "repeat-string": "1.6.1"
+      }
     },
     "alphanum-sort": {
       "version": "1.0.2",
@@ -200,7 +299,11 @@
     "angular-linky": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/angular-linky/-/angular-linky-1.2.2.tgz",
-      "integrity": "sha1-J1Qm30njm3WdjM3wHBeOactn2Gg="
+      "integrity": "sha1-J1Qm30njm3WdjM3wHBeOactn2Gg=",
+      "requires": {
+        "@types/autolinker": "0.24.28",
+        "autolinker": "1.4.3"
+      }
     },
     "angular-tag-cloud-module": {
       "version": "1.3.2",
@@ -211,7 +314,10 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
       "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "string-width": "2.0.0"
+      }
     },
     "ansi-escapes": {
       "version": "1.4.0",
@@ -247,7 +353,11 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
       "integrity": "sha1-o+Uvo5FoyCX/V7AkgSbOWo/5VQc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "arrify": "1.0.1",
+        "micromatch": "2.3.11"
+      }
     },
     "app-root-path": {
       "version": "2.0.1",
@@ -265,19 +375,29 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
       "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "delegates": "1.0.0",
+        "readable-stream": "2.2.9"
+      }
     },
     "argparse": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "sprintf-js": "1.0.3"
+      }
     },
     "arr-diff": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "arr-flatten": "1.0.3"
+      }
     },
     "arr-flatten": {
       "version": "1.0.3",
@@ -313,7 +433,10 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "array-uniq": "1.0.3"
+      }
     },
     "array-uniq": {
       "version": "1.0.3",
@@ -356,13 +479,21 @@
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
       "integrity": "sha1-SLokC0WpKA6UdImQull9IWYX/UA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "bn.js": "4.11.6",
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.0"
+      }
     },
     "assert": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
       "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "util": "0.10.3"
+      }
     },
     "assert-plus": {
       "version": "0.2.0",
@@ -374,7 +505,10 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/async/-/async-2.4.1.tgz",
       "integrity": "sha1-YqVrJ5yYoR0JhwlqAcw+6463u9c=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.4"
+      }
     },
     "async-each": {
       "version": "1.0.1",
@@ -403,7 +537,15 @@
       "version": "6.7.7",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
       "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "browserslist": "1.7.7",
+        "caniuse-db": "1.0.30000676",
+        "normalize-range": "0.1.2",
+        "num2fraction": "1.2.2",
+        "postcss": "5.2.17",
+        "postcss-value-parser": "3.3.0"
+      }
     },
     "aws-sign2": {
       "version": "0.6.0",
@@ -421,13 +563,28 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
       "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.1"
+      }
     },
     "babel-generator": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.24.1.tgz",
       "integrity": "sha1-5xX0hsWN7SVknYiJRNUqoHxdlJc=",
       "dev": true,
+      "requires": {
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.24.1",
+        "detect-indent": "4.0.0",
+        "jsesc": "1.3.0",
+        "lodash": "4.17.4",
+        "source-map": "0.5.6",
+        "trim-right": "1.0.1"
+      },
       "dependencies": {
         "jsesc": {
           "version": "1.3.0",
@@ -441,31 +598,62 @@
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0"
+      }
     },
     "babel-runtime": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
       "integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "core-js": "2.4.1",
+        "regenerator-runtime": "0.10.5"
+      }
     },
     "babel-template": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
       "integrity": "sha1-BK5RTx+Ts6JTfyoPYKWkX7gwgzM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "babel-traverse": "6.24.1",
+        "babel-types": "6.24.1",
+        "babylon": "6.17.2",
+        "lodash": "4.17.4"
+      }
     },
     "babel-traverse": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
       "integrity": "sha1-qzZnP9NW+aCUhlnnszjV/q2zFpU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "6.22.0",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.24.1",
+        "babylon": "6.17.2",
+        "debug": "2.6.8",
+        "globals": "9.17.0",
+        "invariant": "2.2.2",
+        "lodash": "4.17.4"
+      }
     },
     "babel-types": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
       "integrity": "sha1-oTaHncFbNga9oNkMH8dDBML/CXU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "esutils": "2.0.2",
+        "lodash": "4.17.4",
+        "to-fast-properties": "1.0.3"
+      }
     },
     "babylon": {
       "version": "6.17.2",
@@ -514,7 +702,10 @@
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "tweetnacl": "0.14.5"
+      }
     },
     "beeper": {
       "version": "1.1.1",
@@ -532,7 +723,10 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
       "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "callsite": "1.0.0"
+      }
     },
     "big.js": {
       "version": "3.1.3",
@@ -556,7 +750,10 @@
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3"
+      }
     },
     "bluebird": {
       "version": "3.5.0",
@@ -575,6 +772,18 @@
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.17.2.tgz",
       "integrity": "sha1-+IkqvI+eYn1Crtr7yma/WrmRBO4=",
       "dev": true,
+      "requires": {
+        "bytes": "2.4.0",
+        "content-type": "1.0.2",
+        "debug": "2.6.7",
+        "depd": "1.1.0",
+        "http-errors": "1.6.1",
+        "iconv-lite": "0.4.15",
+        "on-finished": "2.3.0",
+        "qs": "6.4.0",
+        "raw-body": "2.2.0",
+        "type-is": "1.6.15"
+      },
       "dependencies": {
         "bytes": {
           "version": "2.4.0",
@@ -586,7 +795,10 @@
           "version": "2.6.7",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
           "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
         },
         "iconv-lite": {
           "version": "0.4.15",
@@ -606,7 +818,10 @@
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "hoek": "2.16.3"
+      }
     },
     "bootstrap": {
       "version": "3.3.7",
@@ -618,6 +833,15 @@
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.1.0.tgz",
       "integrity": "sha1-sbad1SIwXoB6md7ud329blFnsQI=",
       "dev": true,
+      "requires": {
+        "ansi-align": "2.0.0",
+        "camelcase": "4.1.0",
+        "chalk": "1.1.3",
+        "cli-boxes": "1.0.0",
+        "string-width": "2.0.0",
+        "term-size": "0.1.1",
+        "widest-line": "1.0.0"
+      },
       "dependencies": {
         "camelcase": {
           "version": "4.1.0",
@@ -631,13 +855,22 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
       "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "balanced-match": "0.4.2",
+        "concat-map": "0.0.1"
+      }
     },
     "braces": {
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "expand-range": "1.8.2",
+        "preserve": "0.2.0",
+        "repeat-element": "1.1.2"
+      }
     },
     "brorand": {
       "version": "1.1.0",
@@ -649,49 +882,91 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
       "integrity": "sha1-Xncl297x/Vkw1OurSFZ85FHEigo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "buffer-xor": "1.0.3",
+        "cipher-base": "1.0.3",
+        "create-hash": "1.1.3",
+        "evp_bytestokey": "1.0.0",
+        "inherits": "2.0.3"
+      }
     },
     "browserify-cipher": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
       "integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "browserify-aes": "1.0.6",
+        "browserify-des": "1.0.0",
+        "evp_bytestokey": "1.0.0"
+      }
     },
     "browserify-des": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
       "integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "cipher-base": "1.0.3",
+        "des.js": "1.0.0",
+        "inherits": "2.0.3"
+      }
     },
     "browserify-rsa": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "bn.js": "4.11.6",
+        "randombytes": "2.0.3"
+      }
     },
     "browserify-sign": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
       "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "bn.js": "4.11.6",
+        "browserify-rsa": "4.0.1",
+        "create-hash": "1.1.3",
+        "create-hmac": "1.1.6",
+        "elliptic": "6.4.0",
+        "inherits": "2.0.3",
+        "parse-asn1": "5.1.0"
+      }
     },
     "browserify-zlib": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
       "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pako": "0.2.9"
+      }
     },
     "browserslist": {
       "version": "1.7.7",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
       "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "caniuse-db": "1.0.30000676",
+        "electron-to-chromium": "1.3.13"
+      }
     },
     "buffer": {
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "base64-js": "1.2.0",
+        "ieee754": "1.1.8",
+        "isarray": "1.0.0"
+      }
     },
     "buffer-shims": {
       "version": "1.0.0",
@@ -726,7 +1001,10 @@
     "c3": {
       "version": "0.4.13",
       "resolved": "https://registry.npmjs.org/c3/-/c3-0.4.13.tgz",
-      "integrity": "sha1-1nGupaBIzBN8PXRaD8XjxkjOXx4="
+      "integrity": "sha1-1nGupaBIzBN8PXRaD8XjxkjOXx4=",
+      "requires": {
+        "d3": "3.5.17"
+      }
     },
     "callsite": {
       "version": "1.0.0",
@@ -738,7 +1016,11 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
       "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "no-case": "2.3.1",
+        "upper-case": "1.1.3"
+      }
     },
     "camelcase": {
       "version": "2.1.1",
@@ -750,13 +1032,23 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "camelcase": "2.1.1",
+        "map-obj": "1.0.1"
+      }
     },
     "caniuse-api": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.6.1.tgz",
       "integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "browserslist": "1.7.7",
+        "caniuse-db": "1.0.30000676",
+        "lodash.memoize": "4.1.2",
+        "lodash.uniq": "4.5.0"
+      }
     },
     "caniuse-db": {
       "version": "1.0.30000676",
@@ -780,13 +1072,24 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "align-text": "0.1.4",
+        "lazy-cache": "1.0.4"
+      }
     },
     "chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
+      "requires": {
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
+      },
       "dependencies": {
         "supports-color": {
           "version": "2.0.0",
@@ -800,25 +1103,44 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "anymatch": "1.3.0",
+        "async-each": "1.0.1",
+        "glob-parent": "2.0.0",
+        "inherits": "2.0.3",
+        "is-binary-path": "1.0.1",
+        "is-glob": "2.0.1",
+        "path-is-absolute": "1.0.1",
+        "readdirp": "2.1.0"
+      }
     },
     "cipher-base": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.3.tgz",
       "integrity": "sha1-7qvxlEGc6QDaMBjCB9IS8qbfCgc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3"
+      }
     },
     "clap": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/clap/-/clap-1.1.3.tgz",
       "integrity": "sha1-s7026T3Uy/s5WjwmiWNSRFJlwFs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3"
+      }
     },
     "clean-css": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.1.3.tgz",
       "integrity": "sha1-B8/omA7bINRV3cI6rc8eBMblCc4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "source-map": "0.5.6"
+      }
     },
     "cli-boxes": {
       "version": "1.0.0",
@@ -830,7 +1152,10 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "restore-cursor": "2.0.0"
+      }
     },
     "cli-width": {
       "version": "2.1.0",
@@ -843,18 +1168,31 @@
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
       "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
       "dev": true,
+      "requires": {
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wrap-ansi": "2.1.0"
+      },
       "dependencies": {
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
         },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
         }
       }
     },
@@ -868,7 +1206,14 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
       "integrity": "sha1-TnPdCen7lxzDhnDF3O2cGJZIHMY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "for-own": "0.1.5",
+        "is-plain-object": "2.0.3",
+        "kind-of": "3.2.2",
+        "lazy-cache": "1.0.4",
+        "shallow-clone": "0.1.2"
+      }
     },
     "clone-stats": {
       "version": "0.0.1",
@@ -886,7 +1231,10 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.2.tgz",
       "integrity": "sha1-K6n+w7SqQ9eknX5sNWHpIGG2vOw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "q": "1.5.0"
+      }
     },
     "code-point-at": {
       "version": "1.1.0",
@@ -898,19 +1246,35 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/codelyzer/-/codelyzer-2.1.1.tgz",
       "integrity": "sha1-BXPH+NpKwqRHOwBCgH97kB3siwo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "app-root-path": "2.0.1",
+        "css-selector-tokenizer": "0.7.0",
+        "cssauron": "1.4.0",
+        "semver-dsl": "1.0.1",
+        "source-map": "0.5.6",
+        "sprintf-js": "1.0.3"
+      }
     },
     "color": {
       "version": "0.11.4",
       "resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
       "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "clone": "1.0.2",
+        "color-convert": "1.9.0",
+        "color-string": "0.3.0"
+      }
     },
     "color-convert": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
       "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.2"
+      }
     },
     "color-name": {
       "version": "1.1.2",
@@ -922,13 +1286,21 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
       "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.2"
+      }
     },
     "colormin": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz",
       "integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "color": "0.11.4",
+        "css-color-names": "0.0.4",
+        "has": "1.0.1"
+      }
     },
     "colors": {
       "version": "1.1.2",
@@ -940,25 +1312,37 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/combine-lists/-/combine-lists-1.0.1.tgz",
       "integrity": "sha1-RYwH4J4NkA/Ci3Cj/sLazR0st/Y=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.4"
+      }
     },
     "combined-stream": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
     },
     "commander": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
       "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-readlink": "1.0.1"
+      }
     },
     "common-tags": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.4.0.tgz",
       "integrity": "sha1-EYe+Tz1M8MBCfUP3Tu8fc1AWFMA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0"
+      }
     },
     "component-bind": {
       "version": "1.0.0",
@@ -982,19 +1366,33 @@
       "version": "2.0.10",
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.10.tgz",
       "integrity": "sha1-/tocf3YXkScyspv4zyYlKiC57s0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "mime-db": "1.27.0"
+      }
     },
     "compression": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/compression/-/compression-1.6.2.tgz",
       "integrity": "sha1-zOsSHsydCcUtetDDNQ6pPd1AK8M=",
       "dev": true,
+      "requires": {
+        "accepts": "1.3.3",
+        "bytes": "2.3.0",
+        "compressible": "2.0.10",
+        "debug": "2.2.0",
+        "on-headers": "1.0.1",
+        "vary": "1.1.1"
+      },
       "dependencies": {
         "debug": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "0.7.1"
+          }
         },
         "ms": {
           "version": "0.7.1",
@@ -1014,19 +1412,36 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.0.tgz",
       "integrity": "sha1-Rd+QcHPibfoc9LLVL1tgVF6qEdE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "dot-prop": "4.1.1",
+        "graceful-fs": "4.1.11",
+        "make-dir": "1.0.0",
+        "unique-string": "1.0.0",
+        "write-file-atomic": "2.1.0",
+        "xdg-basedir": "3.0.0"
+      }
     },
     "connect": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.2.tgz",
       "integrity": "sha1-aU6NIGgb/kkCgsiriGvpjwn0L+c=",
       "dev": true,
+      "requires": {
+        "debug": "2.6.7",
+        "finalhandler": "1.0.3",
+        "parseurl": "1.3.1",
+        "utils-merge": "1.0.0"
+      },
       "dependencies": {
         "debug": {
           "version": "2.6.7",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
           "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
         }
       }
     },
@@ -1040,7 +1455,10 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "date-now": "0.1.4"
+      }
     },
     "console-control-strings": {
       "version": "1.1.0",
@@ -1099,55 +1517,108 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.1.3.tgz",
       "integrity": "sha1-lSdx6w3dwcs/ovb75RpSLpOz7go=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-directory": "0.3.1",
+        "js-yaml": "3.7.0",
+        "minimist": "1.2.0",
+        "object-assign": "4.1.1",
+        "os-homedir": "1.0.2",
+        "parse-json": "2.2.0",
+        "require-from-string": "1.2.1"
+      }
     },
     "create-ecdh": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
       "integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "bn.js": "4.11.6",
+        "elliptic": "6.4.0"
+      }
     },
     "create-error-class": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "capture-stack-trace": "1.0.0"
+      }
     },
     "create-hash": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
       "integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "cipher-base": "1.0.3",
+        "inherits": "2.0.3",
+        "ripemd160": "2.0.1",
+        "sha.js": "2.4.8"
+      }
     },
     "create-hmac": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
       "integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "cipher-base": "1.0.3",
+        "create-hash": "1.1.3",
+        "inherits": "2.0.3",
+        "ripemd160": "2.0.1",
+        "safe-buffer": "5.0.1",
+        "sha.js": "2.4.8"
+      }
     },
     "cross-spawn": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
       "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lru-cache": "4.0.2",
+        "which": "1.2.14"
+      }
     },
     "cross-spawn-async": {
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz",
       "integrity": "sha1-hF/wwINKPe2dFg2sptOQkGuyiMw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lru-cache": "4.0.2",
+        "which": "1.2.14"
+      }
     },
     "cryptiles": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
       "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "boom": "2.10.1"
+      }
     },
     "crypto-browserify": {
       "version": "3.11.0",
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.0.tgz",
       "integrity": "sha1-NlKgkGq5sqfgw85mpAjpV6JIVSI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "browserify-cipher": "1.0.0",
+        "browserify-sign": "4.0.4",
+        "create-ecdh": "4.0.0",
+        "create-hash": "1.1.3",
+        "create-hmac": "1.1.6",
+        "diffie-hellman": "5.0.2",
+        "inherits": "2.0.3",
+        "pbkdf2": "3.0.12",
+        "public-encrypt": "4.0.0",
+        "randombytes": "2.0.3"
+      }
     },
     "crypto-random-string": {
       "version": "1.0.0",
@@ -1165,7 +1636,23 @@
       "version": "0.28.4",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.28.4.tgz",
       "integrity": "sha1-bPNXkZLONV6LONX0Ldeh8uyJjQ8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "6.22.0",
+        "css-selector-tokenizer": "0.7.0",
+        "cssnano": "3.10.0",
+        "icss-utils": "2.1.0",
+        "loader-utils": "1.1.0",
+        "lodash.camelcase": "4.3.0",
+        "object-assign": "4.1.1",
+        "postcss": "5.2.17",
+        "postcss-modules-extract-imports": "1.1.0",
+        "postcss-modules-local-by-default": "1.2.0",
+        "postcss-modules-scope": "1.1.0",
+        "postcss-modules-values": "1.3.0",
+        "postcss-value-parser": "3.3.0",
+        "source-list-map": "0.1.8"
+      }
     },
     "css-parse": {
       "version": "1.7.0",
@@ -1177,13 +1664,24 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
       "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "boolbase": "1.0.0",
+        "css-what": "2.1.0",
+        "domutils": "1.5.1",
+        "nth-check": "1.0.1"
+      }
     },
     "css-selector-tokenizer": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
       "integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "cssesc": "0.1.0",
+        "fastparse": "1.1.1",
+        "regexpu-core": "1.0.0"
+      }
     },
     "css-what": {
       "version": "2.1.0",
@@ -1195,7 +1693,10 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/cssauron/-/cssauron-1.4.0.tgz",
       "integrity": "sha1-pmAt/34EqDBtwNuaVR6S6LVmKtg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "through": "2.3.8"
+      }
     },
     "cssesc": {
       "version": "0.1.0",
@@ -1207,19 +1708,60 @@
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
       "integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "autoprefixer": "6.7.7",
+        "decamelize": "1.2.0",
+        "defined": "1.0.0",
+        "has": "1.0.1",
+        "object-assign": "4.1.1",
+        "postcss": "5.2.17",
+        "postcss-calc": "5.3.1",
+        "postcss-colormin": "2.2.2",
+        "postcss-convert-values": "2.6.1",
+        "postcss-discard-comments": "2.0.4",
+        "postcss-discard-duplicates": "2.1.0",
+        "postcss-discard-empty": "2.1.0",
+        "postcss-discard-overridden": "0.1.1",
+        "postcss-discard-unused": "2.2.3",
+        "postcss-filter-plugins": "2.0.2",
+        "postcss-merge-idents": "2.1.7",
+        "postcss-merge-longhand": "2.0.2",
+        "postcss-merge-rules": "2.1.2",
+        "postcss-minify-font-values": "1.0.5",
+        "postcss-minify-gradients": "1.0.5",
+        "postcss-minify-params": "1.2.2",
+        "postcss-minify-selectors": "2.1.1",
+        "postcss-normalize-charset": "1.1.1",
+        "postcss-normalize-url": "3.0.8",
+        "postcss-ordered-values": "2.2.3",
+        "postcss-reduce-idents": "2.4.0",
+        "postcss-reduce-initial": "1.0.1",
+        "postcss-reduce-transforms": "1.0.4",
+        "postcss-svgo": "2.1.6",
+        "postcss-unique-selectors": "2.0.2",
+        "postcss-value-parser": "3.3.0",
+        "postcss-zindex": "2.2.0"
+      }
     },
     "csso": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/csso/-/csso-2.3.2.tgz",
       "integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "clap": "1.1.3",
+        "source-map": "0.5.6"
+      }
     },
     "currently-unhandled": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "array-find-index": "1.0.2"
+      }
     },
     "custom-event": {
       "version": "1.0.1",
@@ -1237,6 +1779,9 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -1256,13 +1801,20 @@
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
       "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "get-stdin": "4.0.1",
+        "meow": "3.7.0"
+      }
     },
     "debug": {
       "version": "2.6.8",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
       "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
     },
     "decamelize": {
       "version": "1.2.0",
@@ -1292,7 +1844,16 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "globby": "5.0.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.0",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "rimraf": "2.6.1"
+      }
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -1322,7 +1883,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
       "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.0"
+      }
     },
     "destroy": {
       "version": "1.0.4",
@@ -1334,7 +1899,10 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "repeating": "2.0.1"
+      }
     },
     "detect-node": {
       "version": "2.0.3",
@@ -1358,19 +1926,35 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
       "integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "bn.js": "4.11.6",
+        "miller-rabin": "4.0.0",
+        "randombytes": "2.0.3"
+      }
     },
     "directory-encoder": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/directory-encoder/-/directory-encoder-0.7.2.tgz",
       "integrity": "sha1-WbTiqk8lQi9sY7UntGL14tDdLFg=",
       "dev": true,
+      "requires": {
+        "fs-extra": "0.23.1",
+        "handlebars": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
+        "img-stats": "0.5.2"
+      },
       "dependencies": {
         "fs-extra": {
           "version": "0.23.1",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.23.1.tgz",
           "integrity": "sha1-ZhHbpq3yq43Jxp+rN83fiBgVfj0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "jsonfile": "2.4.0",
+            "path-is-absolute": "1.0.1",
+            "rimraf": "2.6.1"
+          }
         }
       }
     },
@@ -1379,6 +1963,9 @@
       "resolved": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.1.4.tgz",
       "integrity": "sha1-pF71cnuJDJv/5tfIduexnLDhfzs=",
       "dev": true,
+      "requires": {
+        "utila": "0.3.3"
+      },
       "dependencies": {
         "utila": {
           "version": "0.3.3",
@@ -1392,13 +1979,23 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/dom-serialize/-/dom-serialize-2.2.1.tgz",
       "integrity": "sha1-ViromZ9Evl6jB29UGdzVnrQ6yVs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "custom-event": "1.0.1",
+        "ent": "2.2.0",
+        "extend": "3.0.1",
+        "void-elements": "2.0.1"
+      }
     },
     "dom-serializer": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
       "dev": true,
+      "requires": {
+        "domelementtype": "1.1.3",
+        "entities": "1.1.1"
+      },
       "dependencies": {
         "domelementtype": {
           "version": "1.1.3",
@@ -1424,25 +2021,38 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.1.0.tgz",
       "integrity": "sha1-0mRvXlf2w7qxHPbLBdPArPdBJZQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "domelementtype": "1.3.0"
+      }
     },
     "domutils": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
       "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "dom-serializer": "0.1.0",
+        "domelementtype": "1.3.0"
+      }
     },
     "dot-prop": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.1.1.tgz",
       "integrity": "sha1-qEk/C3te7sglJbXHWH+n3nyoWcE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-obj": "1.0.1"
+      }
     },
     "duplexer2": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
       "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
       "dev": true,
+      "requires": {
+        "readable-stream": "1.1.14"
+      },
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
@@ -1454,7 +2064,13 @@
           "version": "1.1.14",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
         },
         "string_decoder": {
           "version": "0.10.31",
@@ -1475,7 +2091,10 @@
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "jsbn": "0.1.1"
+      }
     },
     "ee-first": {
       "version": "1.1.1",
@@ -1493,13 +2112,25 @@
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
       "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "bn.js": "4.11.6",
+        "brorand": "1.1.0",
+        "hash.js": "1.0.3",
+        "hmac-drbg": "1.0.1",
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.0",
+        "minimalistic-crypto-utils": "1.0.1"
+      }
     },
     "ember-cli-normalize-entity-name": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/ember-cli-normalize-entity-name/-/ember-cli-normalize-entity-name-1.0.0.tgz",
       "integrity": "sha1-CxT3vLxZmqEXtf3cgeT9A8S61bc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "silent-error": "1.1.0"
+      }
     },
     "ember-cli-string-utils": {
       "version": "1.1.0",
@@ -1524,18 +2155,32 @@
       "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.6.10.tgz",
       "integrity": "sha1-+H2E4b0h0aLsf43u8MYgVKzfsno=",
       "dev": true,
+      "requires": {
+        "accepts": "1.1.4",
+        "base64id": "0.1.0",
+        "debug": "2.2.0",
+        "engine.io-parser": "1.2.4",
+        "ws": "1.0.1"
+      },
       "dependencies": {
         "accepts": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
           "integrity": "sha1-1xyW99QdD+2iw4zRToonwEFY30o=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "mime-types": "2.0.14",
+            "negotiator": "0.4.9"
+          }
         },
         "debug": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "0.7.1"
+          }
         },
         "mime-db": {
           "version": "1.12.0",
@@ -1547,7 +2192,10 @@
           "version": "2.0.14",
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
           "integrity": "sha1-MQ4VnbI+B3+Lsit0jav6SVcUCqY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "mime-db": "1.12.0"
+          }
         },
         "ms": {
           "version": "0.7.1",
@@ -1568,12 +2216,29 @@
       "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.6.9.tgz",
       "integrity": "sha1-HWrUgEilCDyVCWlDsp0279shJAE=",
       "dev": true,
+      "requires": {
+        "component-emitter": "1.1.2",
+        "component-inherit": "0.0.3",
+        "debug": "2.2.0",
+        "engine.io-parser": "1.2.4",
+        "has-cors": "1.1.0",
+        "indexof": "0.0.1",
+        "parsejson": "0.0.1",
+        "parseqs": "0.0.2",
+        "parseuri": "0.0.4",
+        "ws": "1.0.1",
+        "xmlhttprequest-ssl": "1.5.1",
+        "yeast": "0.1.2"
+      },
       "dependencies": {
         "debug": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "0.7.1"
+          }
         },
         "ms": {
           "version": "0.7.1",
@@ -1588,12 +2253,23 @@
       "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.2.4.tgz",
       "integrity": "sha1-4Il7C/FOeS1M0qWVBVORnFaUjEI=",
       "dev": true,
+      "requires": {
+        "after": "0.8.1",
+        "arraybuffer.slice": "0.0.6",
+        "base64-arraybuffer": "0.1.2",
+        "blob": "0.0.4",
+        "has-binary": "0.1.6",
+        "utf8": "2.1.0"
+      },
       "dependencies": {
         "has-binary": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
           "integrity": "sha1-JTJvOc+k9hath4eJTjryz7x7bhA=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "isarray": "0.0.1"
+          }
         },
         "isarray": {
           "version": "0.0.1",
@@ -1607,7 +2283,13 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.1.0.tgz",
       "integrity": "sha1-n0tib1dyRe3PSyrYPYbhf09CHew=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "memory-fs": "0.4.1",
+        "object-assign": "4.1.1",
+        "tapable": "0.2.6"
+      }
     },
     "ensure-posix-path": {
       "version": "1.0.2",
@@ -1631,13 +2313,19 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
       "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "prr": "0.0.0"
+      }
     },
     "error-ex": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-arrayish": "0.2.1"
+      }
     },
     "escape-html": {
       "version": "1.0.3",
@@ -1656,13 +2344,23 @@
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
       "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
       "dev": true,
+      "requires": {
+        "esprima": "2.7.3",
+        "estraverse": "1.9.3",
+        "esutils": "2.0.2",
+        "optionator": "0.8.2",
+        "source-map": "0.2.0"
+      },
       "dependencies": {
         "source-map": {
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
           "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
         }
       }
     },
@@ -1706,19 +2404,33 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
       "integrity": "sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "original": "1.0.0"
+      }
     },
     "evp_bytestokey": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz",
       "integrity": "sha1-SXtmrZ/vZc18CKYYCCS6FHa2blM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "create-hash": "1.1.3"
+      }
     },
     "execa": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.4.0.tgz",
       "integrity": "sha1-TrZGejaglfq7KXD/nV4/t7zm68M=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "cross-spawn-async": "2.2.5",
+        "is-stream": "1.1.0",
+        "npm-run-path": "1.0.0",
+        "object-assign": "4.1.1",
+        "path-key": "1.0.0",
+        "strip-eof": "1.0.0"
+      }
     },
     "exit": {
       "version": "0.1.2",
@@ -1731,18 +2443,30 @@
       "resolved": "https://registry.npmjs.org/expand-braces/-/expand-braces-0.1.2.tgz",
       "integrity": "sha1-SIsdHSRRyz06axks/AMPRMWFX+o=",
       "dev": true,
+      "requires": {
+        "array-slice": "0.2.3",
+        "array-unique": "0.2.1",
+        "braces": "0.1.5"
+      },
       "dependencies": {
         "braces": {
           "version": "0.1.5",
           "resolved": "https://registry.npmjs.org/braces/-/braces-0.1.5.tgz",
           "integrity": "sha1-wIVxEIUpHYt1/ddOqw+FlygHEeY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "expand-range": "0.1.1"
+          }
         },
         "expand-range": {
           "version": "0.1.1",
           "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-0.1.1.tgz",
           "integrity": "sha1-TLjtoJk8pW+k9B/ELzy7TMrf8EQ=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-number": "0.1.1",
+            "repeat-string": "0.2.2"
+          }
         },
         "is-number": {
           "version": "0.1.1",
@@ -1762,31 +2486,74 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-posix-bracket": "0.1.1"
+      }
     },
     "expand-range": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "fill-range": "2.2.3"
+      }
     },
     "exports-loader": {
       "version": "0.6.4",
       "resolved": "https://registry.npmjs.org/exports-loader/-/exports-loader-0.6.4.tgz",
       "integrity": "sha1-1w/GEhl1s1/BKDDPUnVL4nQPyIY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "loader-utils": "1.1.0",
+        "source-map": "0.5.6"
+      }
     },
     "express": {
       "version": "4.15.3",
       "resolved": "https://registry.npmjs.org/express/-/express-4.15.3.tgz",
       "integrity": "sha1-urZdDwOqgMNYQIly/HAPkWlEtmI=",
       "dev": true,
+      "requires": {
+        "accepts": "1.3.3",
+        "array-flatten": "1.1.1",
+        "content-disposition": "0.5.2",
+        "content-type": "1.0.2",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.7",
+        "depd": "1.1.0",
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
+        "etag": "1.8.0",
+        "finalhandler": "1.0.3",
+        "fresh": "0.5.0",
+        "merge-descriptors": "1.0.1",
+        "methods": "1.1.2",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.1",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "1.1.4",
+        "qs": "6.4.0",
+        "range-parser": "1.2.0",
+        "send": "0.15.3",
+        "serve-static": "1.12.3",
+        "setprototypeof": "1.0.3",
+        "statuses": "1.3.1",
+        "type-is": "1.6.15",
+        "utils-merge": "1.0.0",
+        "vary": "1.1.1"
+      },
       "dependencies": {
         "debug": {
           "version": "2.6.7",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
           "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
         }
       }
     },
@@ -1800,19 +2567,33 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.0.4.tgz",
       "integrity": "sha1-HtkZnanL/i7y96MbL96LDRI2iXI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "iconv-lite": "0.4.17",
+        "jschardet": "1.4.2",
+        "tmp": "0.0.31"
+      }
     },
     "extglob": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-extglob": "1.0.0"
+      }
     },
     "extract-text-webpack-plugin": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/extract-text-webpack-plugin/-/extract-text-webpack-plugin-2.1.0.tgz",
       "integrity": "sha1-aTFbiF+Hbb+W04Gfap8cynrr8Vk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ajv": "4.11.8",
+        "async": "2.4.1",
+        "loader-utils": "1.1.0",
+        "webpack-sources": "0.1.5"
+      }
     },
     "extsprintf": {
       "version": "1.0.2",
@@ -1824,7 +2605,11 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
       "integrity": "sha1-Rb4X0Cu5kX1gzP/UmVyZnmyMmUg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "time-stamp": "1.1.0"
+      }
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -1842,19 +2627,28 @@
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
       "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "websocket-driver": "0.6.5"
+      }
     },
     "figures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "1.0.5"
+      }
     },
     "file-loader": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-0.10.1.tgz",
       "integrity": "sha1-gVA0EZiR/GRB+1pkwRvJPCLd2EI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "loader-utils": "1.1.0"
+      }
     },
     "filename-regex": {
       "version": "2.0.1",
@@ -1867,18 +2661,32 @@
       "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.2.1.tgz",
       "integrity": "sha1-WI74lzxmI7KnbfRlEFaWuWqsgGc=",
       "dev": true,
+      "requires": {
+        "glob": "5.0.15",
+        "minimatch": "2.0.10"
+      },
       "dependencies": {
         "glob": {
           "version": "5.0.15",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "2.0.10",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
         },
         "minimatch": {
           "version": "2.0.10",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
           "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.7"
+          }
         }
       }
     },
@@ -1887,12 +2695,22 @@
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
       "dev": true,
+      "requires": {
+        "is-number": "2.1.0",
+        "isobject": "2.1.0",
+        "randomatic": "1.1.6",
+        "repeat-element": "1.1.2",
+        "repeat-string": "1.6.1"
+      },
       "dependencies": {
         "isobject": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
           "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "isarray": "1.0.0"
+          }
         }
       }
     },
@@ -1901,12 +2719,24 @@
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.3.tgz",
       "integrity": "sha1-70fneVDpmXgOhgIqVg4yF+DQzIk=",
       "dev": true,
+      "requires": {
+        "debug": "2.6.7",
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.1",
+        "statuses": "1.3.1",
+        "unpipe": "1.0.0"
+      },
       "dependencies": {
         "debug": {
           "version": "2.6.7",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
           "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
         }
       }
     },
@@ -1914,19 +2744,33 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "path-exists": "2.1.0",
+        "pinkie-promise": "2.0.1"
+      }
     },
     "findup-sync": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
       "integrity": "sha1-N5MKpdgWt3fANEXhlmzGeQpMCxY=",
       "dev": true,
+      "requires": {
+        "glob": "5.0.15"
+      },
       "dependencies": {
         "glob": {
           "version": "5.0.15",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
         }
       }
     },
@@ -1951,7 +2795,10 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "for-in": "1.0.2"
+      }
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -1963,7 +2810,12 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
       "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.5",
+        "mime-types": "2.1.15"
+      }
     },
     "forwarded": {
       "version": "0.1.0",
@@ -1981,13 +2833,20 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
       "integrity": "sha1-1qh/JiJxzv6+wwxVNAf7mV2od3o=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "null-check": "1.0.0"
+      }
     },
     "fs-extra": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
       "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "jsonfile": "2.4.0"
+      }
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -1995,706 +2854,17 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
-    "fsevents": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.1.tgz",
-      "integrity": "sha1-8Z/Sj0Pur3YWgOUZogPE0LPTGv8=",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "abbrev": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "aproba": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "are-we-there-yet": {
-          "version": "1.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "asn1": {
-          "version": "0.2.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "assert-plus": {
-          "version": "0.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "aws4": {
-          "version": "1.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "balanced-match": {
-          "version": "0.4.2",
-          "bundled": true,
-          "dev": true
-        },
-        "bcrypt-pbkdf": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "block-stream": {
-          "version": "0.0.9",
-          "bundled": true,
-          "dev": true
-        },
-        "boom": {
-          "version": "2.10.1",
-          "bundled": true,
-          "dev": true
-        },
-        "brace-expansion": {
-          "version": "1.1.6",
-          "bundled": true,
-          "dev": true
-        },
-        "buffer-shims": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "caseless": {
-          "version": "0.11.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true
-        },
-        "commander": {
-          "version": "2.9.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "cryptiles": {
-          "version": "2.0.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "debug": {
-          "version": "2.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "deep-extend": {
-          "version": "0.4.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "ecc-jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "extend": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "extsprintf": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "form-data": {
-          "version": "2.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "fstream": {
-          "version": "1.0.10",
-          "bundled": true,
-          "dev": true
-        },
-        "fstream-ignore": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "gauge": {
-          "version": "2.7.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "generate-function": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "generate-object-property": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "getpass": {
-          "version": "0.1.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "glob": {
-          "version": "7.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "bundled": true,
-          "dev": true
-        },
-        "graceful-readlink": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "har-validator": {
-          "version": "2.0.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "has-ansi": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "hawk": {
-          "version": "3.1.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "bundled": true,
-          "dev": true
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "dev": true
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "ini": {
-          "version": "1.3.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "is-my-json-valid": {
-          "version": "2.15.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "is-property": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "jodid25519": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "jsonpointer": {
-          "version": "4.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "jsprim": {
-          "version": "1.3.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "mime-db": {
-          "version": "1.26.0",
-          "bundled": true,
-          "dev": true
-        },
-        "mime-types": {
-          "version": "2.1.14",
-          "bundled": true,
-          "dev": true
-        },
-        "minimatch": {
-          "version": "3.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "bundled": true,
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "dev": true
-        },
-        "ms": {
-          "version": "0.7.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "node-pre-gyp": {
-          "version": "0.6.33",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "nopt": {
-          "version": "3.0.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "npmlog": {
-          "version": "4.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "pinkie": {
-          "version": "2.0.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "pinkie-promise": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "bundled": true,
-          "dev": true
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "qs": {
-          "version": "6.3.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "rc": {
-          "version": "1.1.7",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "2.2.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "request": {
-          "version": "2.79.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "rimraf": {
-          "version": "2.5.4",
-          "bundled": true,
-          "dev": true
-        },
-        "semver": {
-          "version": "5.3.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "sntp": {
-          "version": "1.0.9",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "sshpk": {
-          "version": "1.10.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "bundled": true,
-          "dev": true
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "tar": {
-          "version": "2.2.1",
-          "bundled": true,
-          "dev": true
-        },
-        "tar-pack": {
-          "version": "3.3.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "dependencies": {
-            "once": {
-              "version": "1.3.3",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "readable-stream": {
-              "version": "2.1.5",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "tough-cookie": {
-          "version": "2.3.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "tunnel-agent": {
-          "version": "0.4.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "uid-number": {
-          "version": "0.0.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "uuid": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "verror": {
-          "version": "1.3.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "wide-align": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "xtend": {
-          "version": "4.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        }
-      }
-    },
     "fstream": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
       "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "inherits": "2.0.3",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.1"
+      }
     },
     "function-bind": {
       "version": "1.1.0",
@@ -2707,18 +2877,36 @@
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "dev": true,
+      "requires": {
+        "aproba": "1.1.1",
+        "console-control-strings": "1.1.0",
+        "has-unicode": "2.0.1",
+        "object-assign": "4.1.1",
+        "signal-exit": "3.0.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wide-align": "1.1.2"
+      },
       "dependencies": {
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
         },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
         }
       }
     },
@@ -2726,7 +2914,10 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.2.tgz",
       "integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "globule": "1.1.0"
+      }
     },
     "get-caller-file": {
       "version": "1.0.2",
@@ -2751,6 +2942,9 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -2764,19 +2958,34 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
     },
     "glob-base": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "glob-parent": "2.0.0",
+        "is-glob": "2.0.1"
+      }
     },
     "glob-parent": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-glob": "2.0.1"
+      }
     },
     "globals": {
       "version": "9.17.0",
@@ -2788,13 +2997,26 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "glob": "7.1.2",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
+      }
     },
     "globule": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/globule/-/globule-1.1.0.tgz",
       "integrity": "sha1-xJNS5NwYPYWJPuglOF65lLtt9F8=",
       "dev": true,
+      "requires": {
+        "glob": "7.1.2",
+        "lodash": "4.16.6",
+        "minimatch": "3.0.4"
+      },
       "dependencies": {
         "lodash": {
           "version": "4.16.6",
@@ -2808,13 +3030,29 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
       "integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "sparkles": "1.0.0"
+      }
     },
     "got": {
       "version": "6.7.1",
       "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
       "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "create-error-class": "3.0.2",
+        "duplexer3": "0.1.4",
+        "get-stream": "3.0.0",
+        "is-redirect": "1.0.0",
+        "is-retry-allowed": "1.1.0",
+        "is-stream": "1.1.0",
+        "lowercase-keys": "1.0.0",
+        "safe-buffer": "5.0.1",
+        "timed-out": "4.0.1",
+        "unzip-response": "2.0.1",
+        "url-parse-lax": "1.0.0"
+      }
     },
     "graceful-fs": {
       "version": "4.1.11",
@@ -2833,6 +3071,26 @@
       "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
       "integrity": "sha1-eJJcS4+LSQBawBoBHFV+YhiUHLs=",
       "dev": true,
+      "requires": {
+        "array-differ": "1.0.0",
+        "array-uniq": "1.0.3",
+        "beeper": "1.1.1",
+        "chalk": "1.1.3",
+        "dateformat": "1.0.12",
+        "fancy-log": "1.3.0",
+        "gulplog": "1.0.0",
+        "has-gulplog": "0.1.0",
+        "lodash._reescape": "3.0.0",
+        "lodash._reevaluate": "3.0.0",
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.template": "3.6.2",
+        "minimist": "1.2.0",
+        "multipipe": "0.1.2",
+        "object-assign": "3.0.0",
+        "replace-ext": "0.0.1",
+        "through2": "2.0.1",
+        "vinyl": "0.5.3"
+      },
       "dependencies": {
         "object-assign": {
           "version": "3.0.0",
@@ -2846,7 +3104,10 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
       "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "glogg": "1.0.0"
+      }
     },
     "handle-thing": {
       "version": "1.2.5",
@@ -2855,32 +3116,14 @@
       "dev": true
     },
     "handlebars": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-1.3.0.tgz",
-      "integrity": "sha1-npsTCpPjiUkTItl1zz7BgYw3zjQ=",
+      "version": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
+      "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
       "dev": true,
-      "dependencies": {
-        "async": {
-          "version": "0.2.10",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
-          "dev": true,
-          "optional": true
-        },
-        "source-map": {
-          "version": "0.1.43",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-          "dev": true,
-          "optional": true
-        },
-        "uglify-js": {
-          "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
-          "integrity": "sha1-+gmEdwtCi3qbKoBY9GNV0U/vIRo=",
-          "dev": true,
-          "optional": true
-        }
+      "requires": {
+        "async": "2.4.1",
+        "optimist": "0.3.7",
+        "source-map": "0.5.6",
+        "uglify-js": "3.0.14"
       }
     },
     "har-schema": {
@@ -2893,25 +3136,38 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
       "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ajv": "4.11.8",
+        "har-schema": "1.0.5"
+      }
     },
     "has": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "function-bind": "1.1.0"
+      }
     },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
     },
     "has-binary": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
       "integrity": "sha1-aOYesWIQyVRaClzOBqhzkS/h5ow=",
       "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      },
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
@@ -2937,7 +3193,10 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
       "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "sparkles": "1.0.0"
+      }
     },
     "has-unicode": {
       "version": "2.0.1",
@@ -2949,19 +3208,31 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
       "integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3"
+      }
     },
     "hash.js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz",
       "integrity": "sha1-EzL/ABVsCg/92CNgE9B7d6BFFXM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3"
+      }
     },
     "hawk": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
       "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "boom": "2.10.1",
+        "cryptiles": "2.0.5",
+        "hoek": "2.16.3",
+        "sntp": "1.0.9"
+      }
     },
     "he": {
       "version": "1.1.1",
@@ -2973,7 +3244,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "hash.js": "1.0.3",
+        "minimalistic-assert": "1.0.0",
+        "minimalistic-crypto-utils": "1.0.1"
+      }
     },
     "hoek": {
       "version": "2.16.3",
@@ -2991,7 +3267,13 @@
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
       "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "obuf": "1.1.1",
+        "readable-stream": "2.2.9",
+        "wbuf": "1.7.2"
+      }
     },
     "html-comment-regex": {
       "version": "1.1.1",
@@ -3009,19 +3291,43 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.2.tgz",
       "integrity": "sha1-1zvD/0SJQkCIGM5gm/P7DqfvTrc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "camel-case": "3.0.0",
+        "clean-css": "4.1.3",
+        "commander": "2.9.0",
+        "he": "1.1.1",
+        "ncname": "1.0.0",
+        "param-case": "2.1.1",
+        "relateurl": "0.2.7",
+        "uglify-js": "3.0.14"
+      }
     },
     "html-webpack-plugin": {
       "version": "2.28.0",
       "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-2.28.0.tgz",
       "integrity": "sha1-LnhjtX5f1I/iYzA+L/yTTDBk0Ak=",
       "dev": true,
+      "requires": {
+        "bluebird": "3.5.0",
+        "html-minifier": "3.5.2",
+        "loader-utils": "0.2.17",
+        "lodash": "4.17.4",
+        "pretty-error": "2.1.0",
+        "toposort": "1.0.3"
+      },
       "dependencies": {
         "loader-utils": {
           "version": "0.2.17",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
           "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "big.js": "3.1.3",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1",
+            "object-assign": "4.1.1"
+          }
         }
       }
     },
@@ -3030,12 +3336,21 @@
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.3.0.tgz",
       "integrity": "sha1-zHDQWln2VC5D8OaFyYLhTJJKnv4=",
       "dev": true,
+      "requires": {
+        "domelementtype": "1.3.0",
+        "domhandler": "2.1.0",
+        "domutils": "1.1.6",
+        "readable-stream": "1.0.34"
+      },
       "dependencies": {
         "domutils": {
           "version": "1.1.6",
           "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.1.6.tgz",
           "integrity": "sha1-vdw94Jm5ou+sxRxiPyj0FuzFdIU=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "domelementtype": "1.3.0"
+          }
         },
         "isarray": {
           "version": "0.0.1",
@@ -3047,7 +3362,13 @@
           "version": "1.0.34",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
         },
         "string_decoder": {
           "version": "0.10.31",
@@ -3067,19 +3388,35 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.1.tgz",
       "integrity": "sha1-X4uO2YrKVFZWv1cplzh/kEpyIlc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "depd": "1.1.0",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.0.3",
+        "statuses": "1.3.1"
+      }
     },
     "http-proxy": {
       "version": "1.16.2",
       "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.16.2.tgz",
       "integrity": "sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "eventemitter3": "1.2.0",
+        "requires-port": "1.0.0"
+      }
     },
     "http-proxy-middleware": {
       "version": "0.17.4",
       "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz",
       "integrity": "sha1-ZC6ISIUdZvCdTxJJEoRtuutBuDM=",
       "dev": true,
+      "requires": {
+        "http-proxy": "1.16.2",
+        "is-glob": "3.1.0",
+        "lodash": "4.17.4",
+        "micromatch": "2.3.11"
+      },
       "dependencies": {
         "is-extglob": {
           "version": "2.1.1",
@@ -3091,7 +3428,10 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-extglob": "2.1.1"
+          }
         }
       }
     },
@@ -3099,7 +3439,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
       "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "assert-plus": "0.2.0",
+        "jsprim": "1.4.0",
+        "sshpk": "1.13.0"
+      }
     },
     "https-browserify": {
       "version": "0.0.1",
@@ -3111,7 +3456,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
       "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "agent-base": "2.1.1",
+        "debug": "2.6.8",
+        "extend": "3.0.1"
+      }
     },
     "ibm-design-colors": {
       "version": "2.0.4",
@@ -3135,12 +3485,20 @@
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-2.1.0.tgz",
       "integrity": "sha1-g/Cg7DeL8yRheLbCrZE28TWxyWI=",
       "dev": true,
+      "requires": {
+        "postcss": "6.0.1"
+      },
       "dependencies": {
         "postcss": {
           "version": "6.0.1",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.1.tgz",
           "integrity": "sha1-AA29H47vIXqjaLmiEsX8QLKo8/I=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "source-map": "0.5.6",
+            "supports-color": "3.2.3"
+          }
         }
       }
     },
@@ -3161,7 +3519,10 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/img-stats/-/img-stats-0.5.2.tgz",
       "integrity": "sha1-wgNJbELy2esuWrgjL6dWurMsnis=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "xmldom": "0.1.27"
+      }
     },
     "imurmurhash": {
       "version": "0.1.4",
@@ -3179,7 +3540,10 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "repeating": "2.0.1"
+      }
     },
     "indexes-of": {
       "version": "1.0.1",
@@ -3203,7 +3567,11 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
     },
     "inherits": {
       "version": "2.0.3",
@@ -3221,7 +3589,22 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.0.6.tgz",
       "integrity": "sha1-4EqqnQW3o8ubD0B9BDdfBEcZA0c=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "1.4.0",
+        "chalk": "1.1.3",
+        "cli-cursor": "2.1.0",
+        "cli-width": "2.1.0",
+        "external-editor": "2.0.4",
+        "figures": "2.0.0",
+        "lodash": "4.17.4",
+        "mute-stream": "0.0.7",
+        "run-async": "2.3.0",
+        "rx": "4.1.0",
+        "string-width": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "through": "2.3.8"
+      }
     },
     "install": {
       "version": "0.10.1",
@@ -3243,7 +3626,10 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
       "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "loose-envify": "1.3.1"
+      }
     },
     "invert-kv": {
       "version": "1.0.0",
@@ -3273,7 +3659,10 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "binary-extensions": "1.8.0"
+      }
     },
     "is-buffer": {
       "version": "1.1.5",
@@ -3285,7 +3674,10 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "builtin-modules": "1.1.1"
+      }
     },
     "is-directory": {
       "version": "0.3.1",
@@ -3303,7 +3695,10 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-primitive": "2.0.0"
+      }
     },
     "is-extendable": {
       "version": "0.1.1",
@@ -3321,7 +3716,10 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
@@ -3333,7 +3731,10 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-extglob": "1.0.0"
+      }
     },
     "is-npm": {
       "version": "1.0.0",
@@ -3345,7 +3746,10 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      }
     },
     "is-obj": {
       "version": "1.0.1",
@@ -3363,13 +3767,19 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-path-inside": "1.0.0"
+      }
     },
     "is-path-inside": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
       "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "path-is-inside": "1.0.2"
+      }
     },
     "is-plain-obj": {
       "version": "1.1.0",
@@ -3381,7 +3791,10 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.3.tgz",
       "integrity": "sha1-wVvz5LZrYtcu+vKSWEhmPsvGGbY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "isobject": "3.0.0"
+      }
     },
     "is-posix-bracket": {
       "version": "0.1.1",
@@ -3423,7 +3836,10 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz",
       "integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "html-comment-regex": "1.1.1"
+      }
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -3472,6 +3888,22 @@
       "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
       "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
       "dev": true,
+      "requires": {
+        "abbrev": "1.0.9",
+        "async": "1.5.2",
+        "escodegen": "1.8.1",
+        "esprima": "2.7.3",
+        "glob": "5.0.15",
+        "handlebars": "4.0.10",
+        "js-yaml": "3.7.0",
+        "mkdirp": "0.5.1",
+        "nopt": "3.0.6",
+        "once": "1.4.0",
+        "resolve": "1.1.7",
+        "supports-color": "3.2.3",
+        "which": "1.2.14",
+        "wordwrap": "1.0.0"
+      },
       "dependencies": {
         "abbrev": {
           "version": "1.0.9",
@@ -3498,6 +3930,11 @@
           "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
           "dev": true,
           "optional": true,
+          "requires": {
+            "center-align": "0.1.3",
+            "right-align": "0.1.3",
+            "wordwrap": "0.0.2"
+          },
           "dependencies": {
             "wordwrap": {
               "version": "0.0.2",
@@ -3512,13 +3949,26 @@
           "version": "5.0.15",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
         },
         "handlebars": {
           "version": "4.0.10",
           "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
           "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "async": "1.5.2",
+            "optimist": "0.6.1",
+            "source-map": "0.4.4",
+            "uglify-js": "2.8.27"
+          }
         },
         "minimist": {
           "version": "0.0.10",
@@ -3530,13 +3980,20 @@
           "version": "3.0.6",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
           "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "abbrev": "1.0.9"
+          }
         },
         "optimist": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
           "dev": true,
+          "requires": {
+            "minimist": "0.0.10",
+            "wordwrap": "0.0.3"
+          },
           "dependencies": {
             "wordwrap": {
               "version": "0.0.3",
@@ -3556,7 +4013,10 @@
           "version": "0.4.4",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
         },
         "uglify-js": {
           "version": "2.8.27",
@@ -3564,6 +4024,11 @@
           "integrity": "sha1-R3h/kSsPJC5bmENDvo416V9pTJw=",
           "dev": true,
           "optional": true,
+          "requires": {
+            "source-map": "0.5.6",
+            "uglify-to-browserify": "1.0.2",
+            "yargs": "3.10.0"
+          },
           "dependencies": {
             "source-map": {
               "version": "0.5.6",
@@ -3585,7 +4050,13 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "camelcase": "1.2.1",
+            "cliui": "2.1.0",
+            "decamelize": "1.2.0",
+            "window-size": "0.1.0"
+          }
         }
       }
     },
@@ -3594,12 +4065,24 @@
       "resolved": "https://registry.npmjs.org/istanbul-instrumenter-loader/-/istanbul-instrumenter-loader-2.0.0.tgz",
       "integrity": "sha1-5UkpAKsLuoNe+oAkywC+mz7qJwA=",
       "dev": true,
+      "requires": {
+        "convert-source-map": "1.5.0",
+        "istanbul-lib-instrument": "1.7.2",
+        "loader-utils": "0.2.17",
+        "object-assign": "4.1.1"
+      },
       "dependencies": {
         "loader-utils": {
           "version": "0.2.17",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
           "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "big.js": "3.1.3",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1",
+            "object-assign": "4.1.1"
+          }
         }
       }
     },
@@ -3613,13 +4096,27 @@
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.2.tgz",
       "integrity": "sha1-YBSwPTRw+3djjVgCUIwlXAYxLlY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-generator": "6.24.1",
+        "babel-template": "6.24.1",
+        "babel-traverse": "6.24.1",
+        "babel-types": "6.24.1",
+        "babylon": "6.17.2",
+        "istanbul-lib-coverage": "1.1.1",
+        "semver": "5.3.0"
+      }
     },
     "jasmine": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-2.6.0.tgz",
       "integrity": "sha1-ayLnCIPo5YnUVjRhU7TSBt2+IX8=",
       "dev": true,
+      "requires": {
+        "exit": "0.1.2",
+        "glob": "7.1.2",
+        "jasmine-core": "2.6.2"
+      },
       "dependencies": {
         "jasmine-core": {
           "version": "2.6.2",
@@ -3639,7 +4136,10 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/jasmine-spec-reporter/-/jasmine-spec-reporter-2.5.0.tgz",
       "integrity": "sha1-EuR4LmRFwN+ruN70xS7dMPY2LUI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "colors": "1.1.2"
+      }
     },
     "jasminewd2": {
       "version": "0.0.10",
@@ -3652,7 +4152,10 @@
       "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
       "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "jsbn": "0.1.1"
+      }
     },
     "jquery": {
       "version": "3.2.1",
@@ -3675,7 +4178,11 @@
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
       "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "argparse": "1.0.9",
+        "esprima": "2.7.3"
+      }
     },
     "jsbn": {
       "version": "0.1.1",
@@ -3712,7 +4219,10 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "jsonify": "0.0.0"
+      }
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -3736,7 +4246,10 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11"
+      }
     },
     "jsonify": {
       "version": "0.0.0",
@@ -3749,6 +4262,12 @@
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
       "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
       "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.0.2",
+        "json-schema": "0.2.3",
+        "verror": "1.3.6"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -3763,6 +4282,33 @@
       "resolved": "https://registry.npmjs.org/karma/-/karma-1.2.0.tgz",
       "integrity": "sha1-bcqJ7CX0dT8SD4NMiTmAmAQP1j4=",
       "dev": true,
+      "requires": {
+        "bluebird": "3.5.0",
+        "body-parser": "1.17.2",
+        "chokidar": "1.7.0",
+        "colors": "1.1.2",
+        "combine-lists": "1.0.1",
+        "connect": "3.6.2",
+        "core-js": "2.4.1",
+        "di": "0.0.1",
+        "dom-serialize": "2.2.1",
+        "expand-braces": "0.1.2",
+        "glob": "7.1.2",
+        "graceful-fs": "4.1.11",
+        "http-proxy": "1.16.2",
+        "isbinaryfile": "3.0.2",
+        "lodash": "3.10.1",
+        "log4js": "0.6.38",
+        "mime": "1.3.6",
+        "minimatch": "3.0.4",
+        "optimist": "0.6.1",
+        "qjobs": "1.1.5",
+        "rimraf": "2.6.1",
+        "socket.io": "1.4.7",
+        "source-map": "0.5.6",
+        "tmp": "0.0.28",
+        "useragent": "2.1.13"
+      },
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
@@ -3780,13 +4326,20 @@
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.10",
+            "wordwrap": "0.0.3"
+          }
         },
         "tmp": {
           "version": "0.0.28",
           "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
           "integrity": "sha1-Fyc1t/YU6nrzlmT6hM8N5OUV0SA=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "os-tmpdir": "1.0.2"
+          }
         }
       }
     },
@@ -3794,13 +4347,20 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-2.1.1.tgz",
       "integrity": "sha1-IWh5xorATY1RQOmWGboEtZr9Rs8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "fs-access": "1.0.1",
+        "which": "1.2.14"
+      }
     },
     "karma-cli": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/karma-cli/-/karma-cli-1.0.1.tgz",
       "integrity": "sha1-rmw8WKMTodALRRZMRVubhs4X+WA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "resolve": "1.3.3"
+      }
     },
     "karma-jasmine": {
       "version": "1.1.0",
@@ -3812,19 +4372,29 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/karma-remap-istanbul/-/karma-remap-istanbul-0.2.2.tgz",
       "integrity": "sha1-HN9shaVcayDpxxScCoxVUzA42dk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "istanbul": "0.4.5",
+        "remap-istanbul": "0.6.4"
+      }
     },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-buffer": "1.1.5"
+      }
     },
     "latest-version": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
       "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "package-json": "4.0.1"
+      }
     },
     "lazy-cache": {
       "version": "1.0.4",
@@ -3842,19 +4412,37 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "invert-kv": "1.0.0"
+      }
     },
     "less": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/less/-/less-2.7.2.tgz",
       "integrity": "sha1-No1sxz4fsDmBGDKAkYdDxdz5s98=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "errno": "0.1.4",
+        "graceful-fs": "4.1.11",
+        "image-size": "0.5.4",
+        "mime": "1.3.6",
+        "mkdirp": "0.5.1",
+        "promise": "7.1.1",
+        "request": "2.81.0",
+        "source-map": "0.5.6"
+      }
     },
     "less-loader": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/less-loader/-/less-loader-4.0.4.tgz",
       "integrity": "sha1-tKjEOEPmXGfS6i6xRltcQjPVAGo=",
       "dev": true,
+      "requires": {
+        "clone": "2.1.1",
+        "loader-utils": "1.1.0",
+        "pify": "2.3.0"
+      },
       "dependencies": {
         "clone": {
           "version": "2.1.1",
@@ -3868,13 +4456,24 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
+      }
     },
     "load-json-file": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "strip-bom": "2.0.0"
+      }
     },
     "loader-runner": {
       "version": "2.3.0",
@@ -3886,7 +4485,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
       "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "big.js": "3.1.3",
+        "emojis-list": "2.1.0",
+        "json5": "0.5.1"
+      }
     },
     "lodash": {
       "version": "4.17.4",
@@ -3970,7 +4574,10 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
       "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._root": "3.0.1"
+      }
     },
     "lodash.isarguments": {
       "version": "3.1.0",
@@ -3988,7 +4595,12 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
+      }
     },
     "lodash.memoize": {
       "version": "4.1.2",
@@ -4018,13 +4630,28 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
       "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "3.0.1",
+        "lodash._basetostring": "3.0.1",
+        "lodash._basevalues": "3.0.0",
+        "lodash._isiterateecall": "3.0.9",
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.escape": "3.2.0",
+        "lodash.keys": "3.1.2",
+        "lodash.restparam": "3.6.1",
+        "lodash.templatesettings": "3.1.1"
+      }
     },
     "lodash.templatesettings": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
       "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.escape": "3.2.0"
+      }
     },
     "lodash.uniq": {
       "version": "4.5.0",
@@ -4037,6 +4664,10 @@
       "resolved": "https://registry.npmjs.org/log4js/-/log4js-0.6.38.tgz",
       "integrity": "sha1-LElBFmldb7JUgJQ9P8hy5mKlIv0=",
       "dev": true,
+      "requires": {
+        "readable-stream": "1.0.34",
+        "semver": "4.3.6"
+      },
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
@@ -4048,7 +4679,13 @@
           "version": "1.0.34",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
         },
         "semver": {
           "version": "4.3.6",
@@ -4074,13 +4711,20 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "js-tokens": "3.0.1"
+      }
     },
     "loud-rejection": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "currently-unhandled": "0.4.1",
+        "signal-exit": "3.0.2"
+      }
     },
     "lower-case": {
       "version": "1.1.4",
@@ -4098,7 +4742,11 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
       "integrity": "sha1-HRdnnAac2l0ECZGgnbwsDbN35V4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
+      }
     },
     "macaddress": {
       "version": "0.2.8",
@@ -4110,13 +4758,19 @@
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.19.1.tgz",
       "integrity": "sha1-FNdoATyvLsj96hakmvgvw3fnUgE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "vlq": "0.2.2"
+      }
     },
     "make-dir": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.0.0.tgz",
       "integrity": "sha1-l6ARdR6R3YfPre9Ygy67BJNt6Xg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pify": "2.3.0"
+      }
     },
     "make-error": {
       "version": "1.3.0",
@@ -4134,7 +4788,10 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.0.4.tgz",
       "integrity": "sha1-L2auCGmZbynkPQtiyD3R1D5YF1U=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "minimatch": "3.0.4"
+      }
     },
     "math-expression-evaluator": {
       "version": "1.2.17",
@@ -4152,13 +4809,29 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
       "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "errno": "0.1.4",
+        "readable-stream": "2.2.9"
+      }
     },
     "meow": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "camelcase-keys": "2.1.0",
+        "decamelize": "1.2.0",
+        "loud-rejection": "1.6.0",
+        "map-obj": "1.0.1",
+        "minimist": "1.2.0",
+        "normalize-package-data": "2.3.8",
+        "object-assign": "4.1.1",
+        "read-pkg-up": "1.0.1",
+        "redent": "1.0.0",
+        "trim-newlines": "1.0.0"
+      }
     },
     "merge-descriptors": {
       "version": "1.0.1",
@@ -4176,13 +4849,32 @@
       "version": "2.3.11",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "arr-diff": "2.0.0",
+        "array-unique": "0.2.1",
+        "braces": "1.8.5",
+        "expand-brackets": "0.1.5",
+        "extglob": "0.3.2",
+        "filename-regex": "2.0.1",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1",
+        "kind-of": "3.2.2",
+        "normalize-path": "2.1.1",
+        "object.omit": "2.0.1",
+        "parse-glob": "3.0.4",
+        "regex-cache": "0.4.3"
+      }
     },
     "miller-rabin": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.0.tgz",
       "integrity": "sha1-SmL7HUKTPAVYOYL0xxb2+55sbT0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "bn.js": "4.11.6",
+        "brorand": "1.1.0"
+      }
     },
     "mime": {
       "version": "1.3.6",
@@ -4200,7 +4892,10 @@
       "version": "2.1.15",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
       "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "mime-db": "1.27.0"
+      }
     },
     "mimic-fn": {
       "version": "1.1.0",
@@ -4224,7 +4919,10 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.7"
+      }
     },
     "minimist": {
       "version": "1.2.0",
@@ -4236,6 +4934,10 @@
       "resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
       "integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
       "dev": true,
+      "requires": {
+        "for-in": "0.1.8",
+        "is-extendable": "0.1.1"
+      },
       "dependencies": {
         "for-in": {
           "version": "0.1.8",
@@ -4249,6 +4951,9 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "0.0.8"
+      },
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
@@ -4272,7 +4977,10 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
       "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "duplexer2": "0.0.2"
+      }
     },
     "mute-stream": {
       "version": "0.0.7",
@@ -4290,7 +4998,10 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/ncname/-/ncname-1.0.0.tgz",
       "integrity": "sha1-W1etGLHKCShk72Kwse2BlPODtxw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "xml-char-classes": "1.0.0"
+      }
     },
     "negotiator": {
       "version": "0.6.1",
@@ -4306,7 +5017,10 @@
     "ng2-bootstrap": {
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/ng2-bootstrap/-/ng2-bootstrap-1.6.3.tgz",
-      "integrity": "sha1-i+9heddDa6VHkBRH8Y/uj/9DVcI="
+      "integrity": "sha1-i+9heddDa6VHkBRH8Y/uj/9DVcI=",
+      "requires": {
+        "moment": "2.18.1"
+      }
     },
     "ng2-page-scroll": {
       "version": "4.0.0-beta.8",
@@ -4321,25 +5035,49 @@
     "ngx-bootstrap": {
       "version": "2.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/ngx-bootstrap/-/ngx-bootstrap-2.0.0-beta.2.tgz",
-      "integrity": "sha1-SszxsJmUsycMK80nDz6Iyagp4qw="
+      "integrity": "sha1-SszxsJmUsycMK80nDz6Iyagp4qw=",
+      "requires": {
+        "moment": "2.18.1"
+      }
     },
     "no-case": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.1.tgz",
       "integrity": "sha1-euuhxzpSGEJlVUt9wDuvcg34AIE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lower-case": "1.1.4"
+      }
     },
     "node-gyp": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.1.tgz",
       "integrity": "sha1-GVYQZ/8YVGSt7UeCEmgfR/1XjLw=",
       "dev": true,
+      "requires": {
+        "fstream": "1.0.11",
+        "glob": "7.1.2",
+        "graceful-fs": "4.1.11",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "nopt": "3.0.6",
+        "npmlog": "4.1.0",
+        "osenv": "0.1.4",
+        "request": "2.81.0",
+        "rimraf": "2.6.1",
+        "semver": "5.3.0",
+        "tar": "2.2.1",
+        "which": "1.2.14"
+      },
       "dependencies": {
         "nopt": {
           "version": "3.0.6",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
           "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "abbrev": "1.1.0"
+          }
         }
       }
     },
@@ -4348,6 +5086,31 @@
       "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.0.0.tgz",
       "integrity": "sha1-o6WeyXAkmFtG6Vg3lkb5bEthZkY=",
       "dev": true,
+      "requires": {
+        "assert": "1.4.1",
+        "browserify-zlib": "0.1.4",
+        "buffer": "4.9.1",
+        "console-browserify": "1.1.0",
+        "constants-browserify": "1.0.0",
+        "crypto-browserify": "3.11.0",
+        "domain-browser": "1.1.7",
+        "events": "1.1.1",
+        "https-browserify": "0.0.1",
+        "os-browserify": "0.2.1",
+        "path-browserify": "0.0.0",
+        "process": "0.11.10",
+        "punycode": "1.4.1",
+        "querystring-es3": "0.2.1",
+        "readable-stream": "2.2.9",
+        "stream-browserify": "2.0.1",
+        "stream-http": "2.7.1",
+        "string_decoder": "0.10.31",
+        "timers-browserify": "2.0.2",
+        "tty-browserify": "0.0.0",
+        "url": "0.11.0",
+        "util": "0.10.3",
+        "vm-browserify": "0.0.4"
+      },
       "dependencies": {
         "string_decoder": {
           "version": "0.10.31",
@@ -4367,25 +5130,58 @@
       "version": "4.5.3",
       "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.5.3.tgz",
       "integrity": "sha1-0JydEXlkEjnRuX/8YjH9zsU+FWg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "async-foreach": "0.1.3",
+        "chalk": "1.1.3",
+        "cross-spawn": "3.0.1",
+        "gaze": "1.1.2",
+        "get-stdin": "4.0.1",
+        "glob": "7.1.2",
+        "in-publish": "2.0.0",
+        "lodash.assign": "4.2.0",
+        "lodash.clonedeep": "4.5.0",
+        "lodash.mergewith": "4.6.0",
+        "meow": "3.7.0",
+        "mkdirp": "0.5.1",
+        "nan": "2.6.2",
+        "node-gyp": "3.6.1",
+        "npmlog": "4.1.0",
+        "request": "2.81.0",
+        "sass-graph": "2.2.4",
+        "stdout-stream": "1.4.0"
+      }
     },
     "nopt": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
       "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "abbrev": "1.1.0",
+        "osenv": "0.1.4"
+      }
     },
     "normalize-package-data": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
       "integrity": "sha1-2Bntoqne29H/pWPqQHHZNngilbs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "2.4.2",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.3.0",
+        "validate-npm-package-license": "3.0.1"
+      }
     },
     "normalize-path": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "remove-trailing-separator": "1.0.1"
+      }
     },
     "normalize-range": {
       "version": "0.1.2",
@@ -4397,13 +5193,134 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
       "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "object-assign": "4.1.1",
+        "prepend-http": "1.0.4",
+        "query-string": "4.3.4",
+        "sort-keys": "1.1.2"
+      }
     },
     "npm": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/npm/-/npm-5.0.2.tgz",
       "integrity": "sha512-PrBhzBJ4cwMebW4RmeIgmD3MkRFOf1PgMR8b3GQovETRytoxJW2s/4X2z8NBgJNyBS/NnXtuzZegLs8PfVg+tw==",
+      "requires": {
+        "JSONStream": "1.3.1",
+        "abbrev": "1.1.0",
+        "ansi-regex": "2.1.1",
+        "ansicolors": "0.3.2",
+        "ansistyles": "0.1.3",
+        "aproba": "1.1.2",
+        "archy": "1.0.0",
+        "bluebird": "3.5.0",
+        "cacache": "9.2.6",
+        "call-limit": "1.1.0",
+        "chownr": "1.0.1",
+        "cmd-shim": "2.0.2",
+        "columnify": "1.5.4",
+        "config-chain": "1.1.11",
+        "debuglog": "1.0.1",
+        "detect-indent": "5.0.0",
+        "dezalgo": "1.0.3",
+        "editor": "1.0.0",
+        "fs-vacuum": "1.2.10",
+        "fs-write-stream-atomic": "1.0.10",
+        "fstream": "1.0.11",
+        "fstream-npm": "1.2.1",
+        "glob": "7.1.2",
+        "graceful-fs": "4.1.11",
+        "has-unicode": "2.0.1",
+        "hosted-git-info": "2.4.2",
+        "iferr": "0.1.5",
+        "imurmurhash": "0.1.4",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "ini": "1.3.4",
+        "init-package-json": "1.10.1",
+        "lazy-property": "1.0.0",
+        "lockfile": "1.0.3",
+        "lodash._baseindexof": "3.1.0",
+        "lodash._baseuniq": "4.6.0",
+        "lodash._bindcallback": "3.0.1",
+        "lodash._cacheindexof": "3.0.2",
+        "lodash._createcache": "3.1.2",
+        "lodash._getnative": "3.9.1",
+        "lodash.clonedeep": "4.5.0",
+        "lodash.restparam": "3.6.1",
+        "lodash.union": "4.6.0",
+        "lodash.uniq": "4.5.0",
+        "lodash.without": "4.4.0",
+        "lru-cache": "4.0.2",
+        "mississippi": "1.3.0",
+        "mkdirp": "0.5.1",
+        "move-concurrently": "1.0.1",
+        "node-gyp": "3.6.2",
+        "nopt": "4.0.1",
+        "normalize-package-data": "2.3.8",
+        "npm-cache-filename": "1.0.2",
+        "npm-install-checks": "3.0.0",
+        "npm-package-arg": "5.1.1",
+        "npm-registry-client": "8.3.0",
+        "npm-user-validate": "1.0.0",
+        "npmlog": "4.1.0",
+        "once": "1.4.0",
+        "opener": "1.4.3",
+        "osenv": "0.1.4",
+        "pacote": "2.7.27",
+        "path-is-inside": "1.0.2",
+        "promise-inflight": "1.0.1",
+        "read": "1.0.7",
+        "read-cmd-shim": "1.0.1",
+        "read-installed": "4.0.3",
+        "read-package-json": "2.0.5",
+        "read-package-tree": "5.1.6",
+        "readable-stream": "2.2.9",
+        "readdir-scoped-modules": "1.0.2",
+        "request": "2.81.0",
+        "retry": "0.10.1",
+        "rimraf": "2.6.1",
+        "safe-buffer": "5.0.1",
+        "semver": "5.3.0",
+        "sha": "2.0.1",
+        "slide": "1.1.6",
+        "sorted-object": "2.0.1",
+        "sorted-union-stream": "2.1.3",
+        "ssri": "4.1.4",
+        "strip-ansi": "3.0.1",
+        "tar": "2.2.1",
+        "text-table": "0.2.0",
+        "uid-number": "0.0.6",
+        "umask": "1.1.0",
+        "unique-filename": "1.1.0",
+        "unpipe": "1.0.0",
+        "update-notifier": "2.1.0",
+        "uuid": "3.0.1",
+        "validate-npm-package-license": "3.0.1",
+        "validate-npm-package-name": "3.0.0",
+        "which": "1.2.14",
+        "wrappy": "1.0.2",
+        "write-file-atomic": "2.1.0"
+      },
       "dependencies": {
+        "JSONStream": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "jsonparse": "1.3.0",
+            "through": "2.3.8"
+          },
+          "dependencies": {
+            "jsonparse": {
+              "version": "1.3.0",
+              "bundled": true
+            },
+            "through": {
+              "version": "2.3.8",
+              "bundled": true
+            }
+          }
+        },
         "abbrev": {
           "version": "1.1.0",
           "bundled": true
@@ -4435,6 +5352,21 @@
         "cacache": {
           "version": "9.2.6",
           "bundled": true,
+          "requires": {
+            "bluebird": "3.5.0",
+            "chownr": "1.0.1",
+            "glob": "7.1.2",
+            "graceful-fs": "4.1.11",
+            "lru-cache": "4.0.2",
+            "mississippi": "1.3.0",
+            "mkdirp": "0.5.1",
+            "move-concurrently": "1.0.1",
+            "promise-inflight": "1.0.1",
+            "rimraf": "2.6.1",
+            "ssri": "4.1.4",
+            "unique-filename": "1.1.0",
+            "y18n": "3.2.1"
+          },
           "dependencies": {
             "y18n": {
               "version": "3.2.1",
@@ -4452,19 +5384,33 @@
         },
         "cmd-shim": {
           "version": "2.0.2",
-          "bundled": true
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "mkdirp": "0.5.1"
+          }
         },
         "columnify": {
           "version": "1.5.4",
           "bundled": true,
+          "requires": {
+            "strip-ansi": "3.0.1",
+            "wcwidth": "1.0.1"
+          },
           "dependencies": {
             "wcwidth": {
               "version": "1.0.1",
               "bundled": true,
+              "requires": {
+                "defaults": "1.0.3"
+              },
               "dependencies": {
                 "defaults": {
                   "version": "1.0.3",
                   "bundled": true,
+                  "requires": {
+                    "clone": "1.0.2"
+                  },
                   "dependencies": {
                     "clone": {
                       "version": "1.0.2",
@@ -4479,6 +5425,10 @@
         "config-chain": {
           "version": "1.1.11",
           "bundled": true,
+          "requires": {
+            "ini": "1.3.4",
+            "proto-list": "1.2.4"
+          },
           "dependencies": {
             "proto-list": {
               "version": "1.2.4",
@@ -4497,6 +5447,10 @@
         "dezalgo": {
           "version": "1.0.3",
           "bundled": true,
+          "requires": {
+            "asap": "2.0.5",
+            "wrappy": "1.0.2"
+          },
           "dependencies": {
             "asap": {
               "version": "2.0.5",
@@ -4510,31 +5464,64 @@
         },
         "fs-vacuum": {
           "version": "1.2.10",
-          "bundled": true
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "path-is-inside": "1.0.2",
+            "rimraf": "2.6.1"
+          }
         },
         "fs-write-stream-atomic": {
           "version": "1.0.10",
-          "bundled": true
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "iferr": "0.1.5",
+            "imurmurhash": "0.1.4",
+            "readable-stream": "2.2.9"
+          }
         },
         "fstream": {
           "version": "1.0.11",
-          "bundled": true
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "inherits": "2.0.3",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.1"
+          }
         },
         "fstream-npm": {
           "version": "1.2.1",
           "bundled": true,
+          "requires": {
+            "fstream-ignore": "1.0.5",
+            "inherits": "2.0.3"
+          },
           "dependencies": {
             "fstream-ignore": {
               "version": "1.0.5",
               "bundled": true,
+              "requires": {
+                "fstream": "1.0.11",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4"
+              },
               "dependencies": {
                 "minimatch": {
                   "version": "3.0.4",
                   "bundled": true,
+                  "requires": {
+                    "brace-expansion": "1.1.7"
+                  },
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.7",
                       "bundled": true,
+                      "requires": {
+                        "balanced-match": "0.4.2",
+                        "concat-map": "0.0.1"
+                      },
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.4.2",
@@ -4555,6 +5542,14 @@
         "glob": {
           "version": "7.1.2",
           "bundled": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          },
           "dependencies": {
             "fs.realpath": {
               "version": "1.0.0",
@@ -4563,10 +5558,17 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "requires": {
+                "brace-expansion": "1.1.7"
+              },
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.7",
                   "bundled": true,
+                  "requires": {
+                    "balanced-match": "0.4.2",
+                    "concat-map": "0.0.1"
+                  },
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.4.2",
@@ -4608,7 +5610,11 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true
+          "bundled": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
         },
         "inherits": {
           "version": "2.0.3",
@@ -4621,24 +5627,23 @@
         "init-package-json": {
           "version": "1.10.1",
           "bundled": true,
+          "requires": {
+            "glob": "7.1.2",
+            "npm-package-arg": "5.1.1",
+            "promzard": "0.3.0",
+            "read": "1.0.7",
+            "read-package-json": "2.0.5",
+            "semver": "5.3.0",
+            "validate-npm-package-license": "3.0.1",
+            "validate-npm-package-name": "3.0.0"
+          },
           "dependencies": {
             "promzard": {
               "version": "0.3.0",
-              "bundled": true
-            }
-          }
-        },
-        "JSONStream": {
-          "version": "1.3.1",
-          "bundled": true,
-          "dependencies": {
-            "jsonparse": {
-              "version": "1.3.0",
-              "bundled": true
-            },
-            "through": {
-              "version": "2.3.8",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "read": "1.0.7"
+              }
             }
           }
         },
@@ -4657,6 +5662,10 @@
         "lodash._baseuniq": {
           "version": "4.6.0",
           "bundled": true,
+          "requires": {
+            "lodash._createset": "4.0.3",
+            "lodash._root": "3.0.1"
+          },
           "dependencies": {
             "lodash._createset": {
               "version": "4.0.3",
@@ -4678,7 +5687,10 @@
         },
         "lodash._createcache": {
           "version": "3.1.2",
-          "bundled": true
+          "bundled": true,
+          "requires": {
+            "lodash._getnative": "3.9.1"
+          }
         },
         "lodash._getnative": {
           "version": "3.9.1",
@@ -4707,6 +5719,10 @@
         "lru-cache": {
           "version": "4.0.2",
           "bundled": true,
+          "requires": {
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
+          },
           "dependencies": {
             "pseudomap": {
               "version": "1.0.2",
@@ -4721,10 +5737,27 @@
         "mississippi": {
           "version": "1.3.0",
           "bundled": true,
+          "requires": {
+            "concat-stream": "1.6.0",
+            "duplexify": "3.5.0",
+            "end-of-stream": "1.4.0",
+            "flush-write-stream": "1.0.2",
+            "from2": "2.3.0",
+            "parallel-transform": "1.1.0",
+            "pump": "1.0.2",
+            "pumpify": "1.3.5",
+            "stream-each": "1.2.0",
+            "through2": "2.0.3"
+          },
           "dependencies": {
             "concat-stream": {
               "version": "1.6.0",
               "bundled": true,
+              "requires": {
+                "inherits": "2.0.3",
+                "readable-stream": "2.2.9",
+                "typedarray": "0.0.6"
+              },
               "dependencies": {
                 "typedarray": {
                   "version": "0.0.6",
@@ -4735,14 +5768,26 @@
             "duplexify": {
               "version": "3.5.0",
               "bundled": true,
+              "requires": {
+                "end-of-stream": "1.0.0",
+                "inherits": "2.0.3",
+                "readable-stream": "2.2.9",
+                "stream-shift": "1.0.0"
+              },
               "dependencies": {
                 "end-of-stream": {
                   "version": "1.0.0",
                   "bundled": true,
+                  "requires": {
+                    "once": "1.3.3"
+                  },
                   "dependencies": {
                     "once": {
                       "version": "1.3.3",
-                      "bundled": true
+                      "bundled": true,
+                      "requires": {
+                        "wrappy": "1.0.2"
+                      }
                     }
                   }
                 },
@@ -4754,19 +5799,35 @@
             },
             "end-of-stream": {
               "version": "1.4.0",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "once": "1.4.0"
+              }
             },
             "flush-write-stream": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "inherits": "2.0.3",
+                "readable-stream": "2.2.9"
+              }
             },
             "from2": {
               "version": "2.3.0",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "inherits": "2.0.3",
+                "readable-stream": "2.2.9"
+              }
             },
             "parallel-transform": {
               "version": "1.1.0",
               "bundled": true,
+              "requires": {
+                "cyclist": "0.2.2",
+                "inherits": "2.0.3",
+                "readable-stream": "2.2.9"
+              },
               "dependencies": {
                 "cyclist": {
                   "version": "0.2.2",
@@ -4776,15 +5837,28 @@
             },
             "pump": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "end-of-stream": "1.4.0",
+                "once": "1.4.0"
+              }
             },
             "pumpify": {
               "version": "1.3.5",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "duplexify": "3.5.0",
+                "inherits": "2.0.3",
+                "pump": "1.0.2"
+              }
             },
             "stream-each": {
               "version": "1.2.0",
               "bundled": true,
+              "requires": {
+                "end-of-stream": "1.4.0",
+                "stream-shift": "1.0.0"
+              },
               "dependencies": {
                 "stream-shift": {
                   "version": "1.0.0",
@@ -4795,6 +5869,10 @@
             "through2": {
               "version": "2.0.3",
               "bundled": true,
+              "requires": {
+                "readable-stream": "2.2.9",
+                "xtend": "4.0.1"
+              },
               "dependencies": {
                 "xtend": {
                   "version": "4.0.1",
@@ -4807,6 +5885,9 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "requires": {
+            "minimist": "0.0.8"
+          },
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
@@ -4817,28 +5898,69 @@
         "move-concurrently": {
           "version": "1.0.1",
           "bundled": true,
+          "requires": {
+            "aproba": "1.1.2",
+            "copy-concurrently": "1.0.3",
+            "fs-write-stream-atomic": "1.0.10",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.1",
+            "run-queue": "1.0.3"
+          },
           "dependencies": {
             "copy-concurrently": {
               "version": "1.0.3",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "aproba": "1.1.2",
+                "fs-write-stream-atomic": "1.0.10",
+                "iferr": "0.1.5",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.1",
+                "run-queue": "1.0.3"
+              }
             },
             "run-queue": {
               "version": "1.0.3",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "aproba": "1.1.2"
+              }
             }
           }
         },
         "node-gyp": {
           "version": "3.6.2",
           "bundled": true,
+          "requires": {
+            "fstream": "1.0.11",
+            "glob": "7.1.2",
+            "graceful-fs": "4.1.11",
+            "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
+            "nopt": "3.0.6",
+            "npmlog": "4.1.0",
+            "osenv": "0.1.4",
+            "request": "2.81.0",
+            "rimraf": "2.6.1",
+            "semver": "5.3.0",
+            "tar": "2.2.1",
+            "which": "1.2.14"
+          },
           "dependencies": {
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "requires": {
+                "brace-expansion": "1.1.7"
+              },
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.7",
                   "bundled": true,
+                  "requires": {
+                    "balanced-match": "0.4.2",
+                    "concat-map": "0.0.1"
+                  },
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.4.2",
@@ -4854,21 +5976,37 @@
             },
             "nopt": {
               "version": "3.0.6",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "abbrev": "1.1.0"
+              }
             }
           }
         },
         "nopt": {
           "version": "4.0.1",
-          "bundled": true
+          "bundled": true,
+          "requires": {
+            "abbrev": "1.1.0",
+            "osenv": "0.1.4"
+          }
         },
         "normalize-package-data": {
           "version": "2.3.8",
           "bundled": true,
+          "requires": {
+            "hosted-git-info": "2.4.2",
+            "is-builtin-module": "1.0.0",
+            "semver": "5.3.0",
+            "validate-npm-package-license": "3.0.1"
+          },
           "dependencies": {
             "is-builtin-module": {
               "version": "1.0.0",
               "bundled": true,
+              "requires": {
+                "builtin-modules": "1.1.1"
+              },
               "dependencies": {
                 "builtin-modules": {
                   "version": "1.1.1",
@@ -4884,19 +6022,46 @@
         },
         "npm-install-checks": {
           "version": "3.0.0",
-          "bundled": true
+          "bundled": true,
+          "requires": {
+            "semver": "5.3.0"
+          }
         },
         "npm-package-arg": {
           "version": "5.1.1",
-          "bundled": true
+          "bundled": true,
+          "requires": {
+            "hosted-git-info": "2.4.2",
+            "osenv": "0.1.4",
+            "semver": "5.3.0",
+            "validate-npm-package-name": "3.0.0"
+          }
         },
         "npm-registry-client": {
           "version": "8.3.0",
           "bundled": true,
+          "requires": {
+            "concat-stream": "1.6.0",
+            "graceful-fs": "4.1.11",
+            "normalize-package-data": "2.3.8",
+            "npm-package-arg": "5.1.1",
+            "npmlog": "4.1.0",
+            "once": "1.4.0",
+            "request": "2.81.0",
+            "retry": "0.10.1",
+            "semver": "5.3.0",
+            "slide": "1.1.6",
+            "ssri": "4.1.4"
+          },
           "dependencies": {
             "concat-stream": {
               "version": "1.6.0",
               "bundled": true,
+              "requires": {
+                "inherits": "2.0.3",
+                "readable-stream": "2.2.9",
+                "typedarray": "0.0.6"
+              },
               "dependencies": {
                 "typedarray": {
                   "version": "0.0.6",
@@ -4913,10 +6078,20 @@
         "npmlog": {
           "version": "4.1.0",
           "bundled": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          },
           "dependencies": {
             "are-we-there-yet": {
               "version": "1.1.4",
               "bundled": true,
+              "requires": {
+                "delegates": "1.0.0",
+                "readable-stream": "2.2.9"
+              },
               "dependencies": {
                 "delegates": {
                   "version": "1.0.0",
@@ -4931,6 +6106,16 @@
             "gauge": {
               "version": "2.7.4",
               "bundled": true,
+              "requires": {
+                "aproba": "1.1.2",
+                "console-control-strings": "1.1.0",
+                "has-unicode": "2.0.1",
+                "object-assign": "4.1.1",
+                "signal-exit": "3.0.2",
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1",
+                "wide-align": "1.1.0"
+              },
               "dependencies": {
                 "object-assign": {
                   "version": "4.1.1",
@@ -4943,6 +6128,11 @@
                 "string-width": {
                   "version": "1.0.2",
                   "bundled": true,
+                  "requires": {
+                    "code-point-at": "1.1.0",
+                    "is-fullwidth-code-point": "1.0.0",
+                    "strip-ansi": "3.0.1"
+                  },
                   "dependencies": {
                     "code-point-at": {
                       "version": "1.1.0",
@@ -4951,6 +6141,9 @@
                     "is-fullwidth-code-point": {
                       "version": "1.0.0",
                       "bundled": true,
+                      "requires": {
+                        "number-is-nan": "1.0.1"
+                      },
                       "dependencies": {
                         "number-is-nan": {
                           "version": "1.0.1",
@@ -4962,7 +6155,10 @@
                 },
                 "wide-align": {
                   "version": "1.1.0",
-                  "bundled": true
+                  "bundled": true,
+                  "requires": {
+                    "string-width": "1.0.2"
+                  }
                 }
               }
             },
@@ -4974,7 +6170,10 @@
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true
+          "bundled": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
         },
         "opener": {
           "version": "1.4.3",
@@ -4983,6 +6182,10 @@
         "osenv": {
           "version": "0.1.4",
           "bundled": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          },
           "dependencies": {
             "os-homedir": {
               "version": "1.0.2",
@@ -4997,18 +6200,60 @@
         "pacote": {
           "version": "2.7.27",
           "bundled": true,
+          "requires": {
+            "bluebird": "3.5.0",
+            "cacache": "9.2.6",
+            "glob": "7.1.2",
+            "lru-cache": "4.0.2",
+            "make-fetch-happen": "2.4.10",
+            "minimatch": "3.0.4",
+            "mississippi": "1.3.0",
+            "normalize-package-data": "2.3.8",
+            "npm-package-arg": "5.1.1",
+            "npm-pick-manifest": "1.0.3",
+            "osenv": "0.1.4",
+            "promise-inflight": "1.0.1",
+            "promise-retry": "1.1.1",
+            "protoduck": "4.0.0",
+            "safe-buffer": "5.0.1",
+            "semver": "5.3.0",
+            "ssri": "4.1.4",
+            "tar-fs": "1.15.2",
+            "tar-stream": "1.5.4",
+            "unique-filename": "1.1.0",
+            "which": "1.2.14"
+          },
           "dependencies": {
             "make-fetch-happen": {
               "version": "2.4.10",
               "bundled": true,
+              "requires": {
+                "agentkeepalive": "3.1.0",
+                "cacache": "9.2.6",
+                "http-cache-semantics": "3.7.3",
+                "http-proxy-agent": "1.0.0",
+                "https-proxy-agent": "1.0.0",
+                "lru-cache": "4.0.2",
+                "mississippi": "1.3.0",
+                "node-fetch-npm": "2.0.1",
+                "promise-retry": "1.1.1",
+                "socks-proxy-agent": "2.1.0",
+                "ssri": "4.1.4"
+              },
               "dependencies": {
                 "agentkeepalive": {
                   "version": "3.1.0",
                   "bundled": true,
+                  "requires": {
+                    "humanize-ms": "1.2.1"
+                  },
                   "dependencies": {
                     "humanize-ms": {
                       "version": "1.2.1",
                       "bundled": true,
+                      "requires": {
+                        "ms": "2.0.0"
+                      },
                       "dependencies": {
                         "ms": {
                           "version": "2.0.0",
@@ -5025,10 +6270,19 @@
                 "http-proxy-agent": {
                   "version": "1.0.0",
                   "bundled": true,
+                  "requires": {
+                    "agent-base": "2.1.1",
+                    "debug": "2.6.8",
+                    "extend": "3.0.1"
+                  },
                   "dependencies": {
                     "agent-base": {
                       "version": "2.1.1",
                       "bundled": true,
+                      "requires": {
+                        "extend": "3.0.1",
+                        "semver": "5.0.3"
+                      },
                       "dependencies": {
                         "semver": {
                           "version": "5.0.3",
@@ -5039,6 +6293,9 @@
                     "debug": {
                       "version": "2.6.8",
                       "bundled": true,
+                      "requires": {
+                        "ms": "2.0.0"
+                      },
                       "dependencies": {
                         "ms": {
                           "version": "2.0.0",
@@ -5055,10 +6312,19 @@
                 "https-proxy-agent": {
                   "version": "1.0.0",
                   "bundled": true,
+                  "requires": {
+                    "agent-base": "2.1.1",
+                    "debug": "2.6.8",
+                    "extend": "3.0.1"
+                  },
                   "dependencies": {
                     "agent-base": {
                       "version": "2.1.1",
                       "bundled": true,
+                      "requires": {
+                        "extend": "3.0.1",
+                        "semver": "5.0.3"
+                      },
                       "dependencies": {
                         "semver": {
                           "version": "5.0.3",
@@ -5069,6 +6335,9 @@
                     "debug": {
                       "version": "2.6.8",
                       "bundled": true,
+                      "requires": {
+                        "ms": "2.0.0"
+                      },
                       "dependencies": {
                         "ms": {
                           "version": "2.0.0",
@@ -5085,10 +6354,18 @@
                 "node-fetch-npm": {
                   "version": "2.0.1",
                   "bundled": true,
+                  "requires": {
+                    "encoding": "0.1.12",
+                    "json-parse-helpfulerror": "1.0.3",
+                    "safe-buffer": "5.0.1"
+                  },
                   "dependencies": {
                     "encoding": {
                       "version": "0.1.12",
                       "bundled": true,
+                      "requires": {
+                        "iconv-lite": "0.4.17"
+                      },
                       "dependencies": {
                         "iconv-lite": {
                           "version": "0.4.17",
@@ -5099,6 +6376,9 @@
                     "json-parse-helpfulerror": {
                       "version": "1.0.3",
                       "bundled": true,
+                      "requires": {
+                        "jju": "1.3.0"
+                      },
                       "dependencies": {
                         "jju": {
                           "version": "1.3.0",
@@ -5111,10 +6391,19 @@
                 "socks-proxy-agent": {
                   "version": "2.1.0",
                   "bundled": true,
+                  "requires": {
+                    "agent-base": "2.1.1",
+                    "extend": "3.0.1",
+                    "socks": "1.1.10"
+                  },
                   "dependencies": {
                     "agent-base": {
                       "version": "2.1.1",
                       "bundled": true,
+                      "requires": {
+                        "extend": "3.0.1",
+                        "semver": "5.0.3"
+                      },
                       "dependencies": {
                         "semver": {
                           "version": "5.0.3",
@@ -5129,6 +6418,10 @@
                     "socks": {
                       "version": "1.1.10",
                       "bundled": true,
+                      "requires": {
+                        "ip": "1.1.5",
+                        "smart-buffer": "1.1.15"
+                      },
                       "dependencies": {
                         "ip": {
                           "version": "1.1.5",
@@ -5147,10 +6440,17 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "requires": {
+                "brace-expansion": "1.1.7"
+              },
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.7",
                   "bundled": true,
+                  "requires": {
+                    "balanced-match": "0.4.2",
+                    "concat-map": "0.0.1"
+                  },
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.4.2",
@@ -5166,11 +6466,19 @@
             },
             "npm-pick-manifest": {
               "version": "1.0.3",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "npm-package-arg": "5.1.1",
+                "semver": "5.3.0"
+              }
             },
             "promise-retry": {
               "version": "1.1.1",
               "bundled": true,
+              "requires": {
+                "err-code": "1.1.2",
+                "retry": "0.10.1"
+              },
               "dependencies": {
                 "err-code": {
                   "version": "1.1.2",
@@ -5181,6 +6489,9 @@
             "protoduck": {
               "version": "4.0.0",
               "bundled": true,
+              "requires": {
+                "genfun": "4.0.1"
+              },
               "dependencies": {
                 "genfun": {
                   "version": "4.0.1",
@@ -5191,14 +6502,27 @@
             "tar-fs": {
               "version": "1.15.2",
               "bundled": true,
+              "requires": {
+                "chownr": "1.0.1",
+                "mkdirp": "0.5.1",
+                "pump": "1.0.2",
+                "tar-stream": "1.5.4"
+              },
               "dependencies": {
                 "pump": {
                   "version": "1.0.2",
                   "bundled": true,
+                  "requires": {
+                    "end-of-stream": "1.4.0",
+                    "once": "1.4.0"
+                  },
                   "dependencies": {
                     "end-of-stream": {
                       "version": "1.4.0",
-                      "bundled": true
+                      "bundled": true,
+                      "requires": {
+                        "once": "1.4.0"
+                      }
                     }
                   }
                 }
@@ -5207,14 +6531,26 @@
             "tar-stream": {
               "version": "1.5.4",
               "bundled": true,
+              "requires": {
+                "bl": "1.2.1",
+                "end-of-stream": "1.4.0",
+                "readable-stream": "2.2.9",
+                "xtend": "4.0.1"
+              },
               "dependencies": {
                 "bl": {
                   "version": "1.2.1",
-                  "bundled": true
+                  "bundled": true,
+                  "requires": {
+                    "readable-stream": "2.2.9"
+                  }
                 },
                 "end-of-stream": {
                   "version": "1.4.0",
-                  "bundled": true
+                  "bundled": true,
+                  "requires": {
+                    "once": "1.4.0"
+                  }
                 },
                 "xtend": {
                   "version": "4.0.1",
@@ -5235,6 +6571,9 @@
         "read": {
           "version": "1.0.7",
           "bundled": true,
+          "requires": {
+            "mute-stream": "0.0.7"
+          },
           "dependencies": {
             "mute-stream": {
               "version": "0.0.7",
@@ -5244,11 +6583,23 @@
         },
         "read-cmd-shim": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11"
+          }
         },
         "read-installed": {
           "version": "4.0.3",
           "bundled": true,
+          "requires": {
+            "debuglog": "1.0.1",
+            "graceful-fs": "4.1.11",
+            "read-package-json": "2.0.5",
+            "readdir-scoped-modules": "1.0.2",
+            "semver": "5.3.0",
+            "slide": "1.1.6",
+            "util-extend": "1.0.3"
+          },
           "dependencies": {
             "util-extend": {
               "version": "1.0.3",
@@ -5259,10 +6610,19 @@
         "read-package-json": {
           "version": "2.0.5",
           "bundled": true,
+          "requires": {
+            "glob": "7.1.2",
+            "graceful-fs": "4.1.11",
+            "json-parse-helpfulerror": "1.0.3",
+            "normalize-package-data": "2.3.8"
+          },
           "dependencies": {
             "json-parse-helpfulerror": {
               "version": "1.0.3",
               "bundled": true,
+              "requires": {
+                "jju": "1.3.0"
+              },
               "dependencies": {
                 "jju": {
                   "version": "1.3.0",
@@ -5274,11 +6634,27 @@
         },
         "read-package-tree": {
           "version": "5.1.6",
-          "bundled": true
+          "bundled": true,
+          "requires": {
+            "debuglog": "1.0.1",
+            "dezalgo": "1.0.3",
+            "once": "1.4.0",
+            "read-package-json": "2.0.5",
+            "readdir-scoped-modules": "1.0.2"
+          }
         },
         "readable-stream": {
           "version": "2.2.9",
           "bundled": true,
+          "requires": {
+            "buffer-shims": "1.0.0",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "1.0.0",
+            "util-deprecate": "1.0.2"
+          },
           "dependencies": {
             "buffer-shims": {
               "version": "1.0.0",
@@ -5298,7 +6674,10 @@
             },
             "string_decoder": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "buffer-shims": "1.0.0"
+              }
             },
             "util-deprecate": {
               "version": "1.0.2",
@@ -5308,11 +6687,41 @@
         },
         "readdir-scoped-modules": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "requires": {
+            "debuglog": "1.0.1",
+            "dezalgo": "1.0.3",
+            "graceful-fs": "4.1.11",
+            "once": "1.4.0"
+          }
         },
         "request": {
           "version": "2.81.0",
           "bundled": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.15",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.0.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.2",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.0.1"
+          },
           "dependencies": {
             "aws-sign2": {
               "version": "0.6.0",
@@ -5329,6 +6738,9 @@
             "combined-stream": {
               "version": "1.0.5",
               "bundled": true,
+              "requires": {
+                "delayed-stream": "1.0.0"
+              },
               "dependencies": {
                 "delayed-stream": {
                   "version": "1.0.0",
@@ -5347,6 +6759,11 @@
             "form-data": {
               "version": "2.1.4",
               "bundled": true,
+              "requires": {
+                "asynckit": "0.4.0",
+                "combined-stream": "1.0.5",
+                "mime-types": "2.1.15"
+              },
               "dependencies": {
                 "asynckit": {
                   "version": "0.4.0",
@@ -5357,10 +6774,18 @@
             "har-validator": {
               "version": "4.2.1",
               "bundled": true,
+              "requires": {
+                "ajv": "4.11.8",
+                "har-schema": "1.0.5"
+              },
               "dependencies": {
                 "ajv": {
                   "version": "4.11.8",
                   "bundled": true,
+                  "requires": {
+                    "co": "4.6.0",
+                    "json-stable-stringify": "1.0.1"
+                  },
                   "dependencies": {
                     "co": {
                       "version": "4.6.0",
@@ -5369,6 +6794,9 @@
                     "json-stable-stringify": {
                       "version": "1.0.1",
                       "bundled": true,
+                      "requires": {
+                        "jsonify": "0.0.0"
+                      },
                       "dependencies": {
                         "jsonify": {
                           "version": "0.0.0",
@@ -5387,14 +6815,26 @@
             "hawk": {
               "version": "3.1.3",
               "bundled": true,
+              "requires": {
+                "boom": "2.10.1",
+                "cryptiles": "2.0.5",
+                "hoek": "2.16.3",
+                "sntp": "1.0.9"
+              },
               "dependencies": {
                 "boom": {
                   "version": "2.10.1",
-                  "bundled": true
+                  "bundled": true,
+                  "requires": {
+                    "hoek": "2.16.3"
+                  }
                 },
                 "cryptiles": {
                   "version": "2.0.5",
-                  "bundled": true
+                  "bundled": true,
+                  "requires": {
+                    "boom": "2.10.1"
+                  }
                 },
                 "hoek": {
                   "version": "2.16.3",
@@ -5402,13 +6842,21 @@
                 },
                 "sntp": {
                   "version": "1.0.9",
-                  "bundled": true
+                  "bundled": true,
+                  "requires": {
+                    "hoek": "2.16.3"
+                  }
                 }
               }
             },
             "http-signature": {
               "version": "1.1.1",
               "bundled": true,
+              "requires": {
+                "assert-plus": "0.2.0",
+                "jsprim": "1.4.0",
+                "sshpk": "1.13.0"
+              },
               "dependencies": {
                 "assert-plus": {
                   "version": "0.2.0",
@@ -5417,6 +6865,12 @@
                 "jsprim": {
                   "version": "1.4.0",
                   "bundled": true,
+                  "requires": {
+                    "assert-plus": "1.0.0",
+                    "extsprintf": "1.0.2",
+                    "json-schema": "0.2.3",
+                    "verror": "1.3.6"
+                  },
                   "dependencies": {
                     "assert-plus": {
                       "version": "1.0.0",
@@ -5432,13 +6886,27 @@
                     },
                     "verror": {
                       "version": "1.3.6",
-                      "bundled": true
+                      "bundled": true,
+                      "requires": {
+                        "extsprintf": "1.0.2"
+                      }
                     }
                   }
                 },
                 "sshpk": {
                   "version": "1.13.0",
                   "bundled": true,
+                  "requires": {
+                    "asn1": "0.2.3",
+                    "assert-plus": "1.0.0",
+                    "bcrypt-pbkdf": "1.0.1",
+                    "dashdash": "1.14.1",
+                    "ecc-jsbn": "0.1.1",
+                    "getpass": "0.1.7",
+                    "jodid25519": "1.0.2",
+                    "jsbn": "0.1.1",
+                    "tweetnacl": "0.14.5"
+                  },
                   "dependencies": {
                     "asn1": {
                       "version": "0.2.3",
@@ -5451,25 +6919,40 @@
                     "bcrypt-pbkdf": {
                       "version": "1.0.1",
                       "bundled": true,
-                      "optional": true
+                      "optional": true,
+                      "requires": {
+                        "tweetnacl": "0.14.5"
+                      }
                     },
                     "dashdash": {
                       "version": "1.14.1",
-                      "bundled": true
+                      "bundled": true,
+                      "requires": {
+                        "assert-plus": "1.0.0"
+                      }
                     },
                     "ecc-jsbn": {
                       "version": "0.1.1",
                       "bundled": true,
-                      "optional": true
+                      "optional": true,
+                      "requires": {
+                        "jsbn": "0.1.1"
+                      }
                     },
                     "getpass": {
                       "version": "0.1.7",
-                      "bundled": true
+                      "bundled": true,
+                      "requires": {
+                        "assert-plus": "1.0.0"
+                      }
                     },
                     "jodid25519": {
                       "version": "1.0.2",
                       "bundled": true,
-                      "optional": true
+                      "optional": true,
+                      "requires": {
+                        "jsbn": "0.1.1"
+                      }
                     },
                     "jsbn": {
                       "version": "0.1.1",
@@ -5500,6 +6983,9 @@
             "mime-types": {
               "version": "2.1.15",
               "bundled": true,
+              "requires": {
+                "mime-db": "1.27.0"
+              },
               "dependencies": {
                 "mime-db": {
                   "version": "1.27.0",
@@ -5530,6 +7016,9 @@
             "tough-cookie": {
               "version": "2.3.2",
               "bundled": true,
+              "requires": {
+                "punycode": "1.4.1"
+              },
               "dependencies": {
                 "punycode": {
                   "version": "1.4.1",
@@ -5539,7 +7028,10 @@
             },
             "tunnel-agent": {
               "version": "0.6.0",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "5.0.1"
+              }
             }
           }
         },
@@ -5549,7 +7041,10 @@
         },
         "rimraf": {
           "version": "2.6.1",
-          "bundled": true
+          "bundled": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
         },
         "safe-buffer": {
           "version": "5.0.1",
@@ -5561,7 +7056,11 @@
         },
         "sha": {
           "version": "2.0.1",
-          "bundled": true
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "readable-stream": "2.2.9"
+          }
         },
         "slide": {
           "version": "1.1.6",
@@ -5574,14 +7073,28 @@
         "sorted-union-stream": {
           "version": "2.1.3",
           "bundled": true,
+          "requires": {
+            "from2": "1.3.0",
+            "stream-iterate": "1.2.0"
+          },
           "dependencies": {
             "from2": {
               "version": "1.3.0",
               "bundled": true,
+              "requires": {
+                "inherits": "2.0.3",
+                "readable-stream": "1.1.14"
+              },
               "dependencies": {
                 "readable-stream": {
                   "version": "1.1.14",
                   "bundled": true,
+                  "requires": {
+                    "core-util-is": "1.0.2",
+                    "inherits": "2.0.3",
+                    "isarray": "0.0.1",
+                    "string_decoder": "0.10.31"
+                  },
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
@@ -5602,6 +7115,10 @@
             "stream-iterate": {
               "version": "1.2.0",
               "bundled": true,
+              "requires": {
+                "readable-stream": "2.2.9",
+                "stream-shift": "1.0.0"
+              },
               "dependencies": {
                 "stream-shift": {
                   "version": "1.0.0",
@@ -5613,19 +7130,33 @@
         },
         "ssri": {
           "version": "4.1.4",
-          "bundled": true
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "bundled": true
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
         },
         "tar": {
           "version": "2.2.1",
           "bundled": true,
+          "requires": {
+            "block-stream": "0.0.9",
+            "fstream": "1.0.11",
+            "inherits": "2.0.3"
+          },
           "dependencies": {
             "block-stream": {
               "version": "0.0.9",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "inherits": "2.0.3"
+              }
             }
           }
         },
@@ -5644,10 +7175,16 @@
         "unique-filename": {
           "version": "1.1.0",
           "bundled": true,
+          "requires": {
+            "unique-slug": "2.0.0"
+          },
           "dependencies": {
             "unique-slug": {
               "version": "2.0.0",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "imurmurhash": "0.1.4"
+              }
             }
           }
         },
@@ -5658,18 +7195,45 @@
         "update-notifier": {
           "version": "2.1.0",
           "bundled": true,
+          "requires": {
+            "boxen": "1.0.0",
+            "chalk": "1.1.3",
+            "configstore": "3.0.0",
+            "is-npm": "1.0.0",
+            "latest-version": "3.1.0",
+            "lazy-req": "2.0.0",
+            "semver-diff": "2.1.0",
+            "xdg-basedir": "3.0.0"
+          },
           "dependencies": {
             "boxen": {
               "version": "1.0.0",
               "bundled": true,
+              "requires": {
+                "ansi-align": "1.1.0",
+                "camelcase": "4.1.0",
+                "chalk": "1.1.3",
+                "cli-boxes": "1.0.0",
+                "string-width": "2.0.0",
+                "term-size": "0.1.1",
+                "widest-line": "1.0.0"
+              },
               "dependencies": {
                 "ansi-align": {
                   "version": "1.1.0",
                   "bundled": true,
+                  "requires": {
+                    "string-width": "1.0.2"
+                  },
                   "dependencies": {
                     "string-width": {
                       "version": "1.0.2",
                       "bundled": true,
+                      "requires": {
+                        "code-point-at": "1.1.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
+                      },
                       "dependencies": {
                         "code-point-at": {
                           "version": "1.1.0",
@@ -5678,6 +7242,9 @@
                         "is-fullwidth-code-point": {
                           "version": "1.0.0",
                           "bundled": true,
+                          "requires": {
+                            "number-is-nan": "1.0.1"
+                          },
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.1",
@@ -5700,6 +7267,10 @@
                 "string-width": {
                   "version": "2.0.0",
                   "bundled": true,
+                  "requires": {
+                    "is-fullwidth-code-point": "2.0.0",
+                    "strip-ansi": "3.0.1"
+                  },
                   "dependencies": {
                     "is-fullwidth-code-point": {
                       "version": "2.0.0",
@@ -5710,14 +7281,29 @@
                 "term-size": {
                   "version": "0.1.1",
                   "bundled": true,
+                  "requires": {
+                    "execa": "0.4.0"
+                  },
                   "dependencies": {
                     "execa": {
                       "version": "0.4.0",
                       "bundled": true,
+                      "requires": {
+                        "cross-spawn-async": "2.2.5",
+                        "is-stream": "1.1.0",
+                        "npm-run-path": "1.0.0",
+                        "object-assign": "4.1.1",
+                        "path-key": "1.0.0",
+                        "strip-eof": "1.0.0"
+                      },
                       "dependencies": {
                         "cross-spawn-async": {
                           "version": "2.2.5",
-                          "bundled": true
+                          "bundled": true,
+                          "requires": {
+                            "lru-cache": "4.0.2",
+                            "which": "1.2.14"
+                          }
                         },
                         "is-stream": {
                           "version": "1.1.0",
@@ -5725,7 +7311,10 @@
                         },
                         "npm-run-path": {
                           "version": "1.0.0",
-                          "bundled": true
+                          "bundled": true,
+                          "requires": {
+                            "path-key": "1.0.0"
+                          }
                         },
                         "object-assign": {
                           "version": "4.1.1",
@@ -5746,10 +7335,18 @@
                 "widest-line": {
                   "version": "1.0.0",
                   "bundled": true,
+                  "requires": {
+                    "string-width": "1.0.2"
+                  },
                   "dependencies": {
                     "string-width": {
                       "version": "1.0.2",
                       "bundled": true,
+                      "requires": {
+                        "code-point-at": "1.1.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
+                      },
                       "dependencies": {
                         "code-point-at": {
                           "version": "1.1.0",
@@ -5758,6 +7355,9 @@
                         "is-fullwidth-code-point": {
                           "version": "1.0.0",
                           "bundled": true,
+                          "requires": {
+                            "number-is-nan": "1.0.1"
+                          },
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.1",
@@ -5774,6 +7374,13 @@
             "chalk": {
               "version": "1.1.3",
               "bundled": true,
+              "requires": {
+                "ansi-styles": "2.2.1",
+                "escape-string-regexp": "1.0.5",
+                "has-ansi": "2.0.0",
+                "strip-ansi": "3.0.1",
+                "supports-color": "2.0.0"
+              },
               "dependencies": {
                 "ansi-styles": {
                   "version": "2.2.1",
@@ -5785,7 +7392,10 @@
                 },
                 "has-ansi": {
                   "version": "2.0.0",
-                  "bundled": true
+                  "bundled": true,
+                  "requires": {
+                    "ansi-regex": "2.1.1"
+                  }
                 },
                 "supports-color": {
                   "version": "2.0.0",
@@ -5796,10 +7406,21 @@
             "configstore": {
               "version": "3.0.0",
               "bundled": true,
+              "requires": {
+                "dot-prop": "4.1.1",
+                "graceful-fs": "4.1.11",
+                "mkdirp": "0.5.1",
+                "unique-string": "1.0.0",
+                "write-file-atomic": "1.3.4",
+                "xdg-basedir": "3.0.0"
+              },
               "dependencies": {
                 "dot-prop": {
                   "version": "4.1.1",
                   "bundled": true,
+                  "requires": {
+                    "is-obj": "1.0.1"
+                  },
                   "dependencies": {
                     "is-obj": {
                       "version": "1.0.1",
@@ -5810,6 +7431,9 @@
                 "unique-string": {
                   "version": "1.0.0",
                   "bundled": true,
+                  "requires": {
+                    "crypto-random-string": "1.0.0"
+                  },
                   "dependencies": {
                     "crypto-random-string": {
                       "version": "1.0.0",
@@ -5819,7 +7443,12 @@
                 },
                 "write-file-atomic": {
                   "version": "1.3.4",
-                  "bundled": true
+                  "bundled": true,
+                  "requires": {
+                    "graceful-fs": "4.1.11",
+                    "imurmurhash": "0.1.4",
+                    "slide": "1.1.6"
+                  }
                 }
               }
             },
@@ -5830,18 +7459,43 @@
             "latest-version": {
               "version": "3.1.0",
               "bundled": true,
+              "requires": {
+                "package-json": "4.0.1"
+              },
               "dependencies": {
                 "package-json": {
                   "version": "4.0.1",
                   "bundled": true,
+                  "requires": {
+                    "got": "6.7.1",
+                    "registry-auth-token": "3.3.0",
+                    "registry-url": "3.1.0",
+                    "semver": "5.3.0"
+                  },
                   "dependencies": {
                     "got": {
                       "version": "6.7.1",
                       "bundled": true,
+                      "requires": {
+                        "create-error-class": "3.0.2",
+                        "duplexer3": "0.1.4",
+                        "get-stream": "3.0.0",
+                        "is-redirect": "1.0.0",
+                        "is-retry-allowed": "1.1.0",
+                        "is-stream": "1.1.0",
+                        "lowercase-keys": "1.0.0",
+                        "safe-buffer": "5.0.1",
+                        "timed-out": "4.0.1",
+                        "unzip-response": "2.0.1",
+                        "url-parse-lax": "1.0.0"
+                      },
                       "dependencies": {
                         "create-error-class": {
                           "version": "3.0.2",
                           "bundled": true,
+                          "requires": {
+                            "capture-stack-trace": "1.0.0"
+                          },
                           "dependencies": {
                             "capture-stack-trace": {
                               "version": "1.0.0",
@@ -5888,6 +7542,9 @@
                         "url-parse-lax": {
                           "version": "1.0.0",
                           "bundled": true,
+                          "requires": {
+                            "prepend-http": "1.0.4"
+                          },
                           "dependencies": {
                             "prepend-http": {
                               "version": "1.0.4",
@@ -5900,10 +7557,20 @@
                     "registry-auth-token": {
                       "version": "3.3.0",
                       "bundled": true,
+                      "requires": {
+                        "rc": "1.2.1",
+                        "safe-buffer": "5.0.1"
+                      },
                       "dependencies": {
                         "rc": {
                           "version": "1.2.1",
                           "bundled": true,
+                          "requires": {
+                            "deep-extend": "0.4.1",
+                            "ini": "1.3.4",
+                            "minimist": "1.2.0",
+                            "strip-json-comments": "2.0.1"
+                          },
                           "dependencies": {
                             "deep-extend": {
                               "version": "0.4.1",
@@ -5928,10 +7595,19 @@
                     "registry-url": {
                       "version": "3.1.0",
                       "bundled": true,
+                      "requires": {
+                        "rc": "1.2.1"
+                      },
                       "dependencies": {
                         "rc": {
                           "version": "1.2.1",
                           "bundled": true,
+                          "requires": {
+                            "deep-extend": "0.4.1",
+                            "ini": "1.3.4",
+                            "minimist": "1.2.0",
+                            "strip-json-comments": "2.0.1"
+                          },
                           "dependencies": {
                             "deep-extend": {
                               "version": "0.4.1",
@@ -5959,7 +7635,10 @@
             },
             "semver-diff": {
               "version": "2.1.0",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "semver": "5.3.0"
+              }
             },
             "xdg-basedir": {
               "version": "3.0.0",
@@ -5974,10 +7653,17 @@
         "validate-npm-package-license": {
           "version": "3.0.1",
           "bundled": true,
+          "requires": {
+            "spdx-correct": "1.0.2",
+            "spdx-expression-parse": "1.0.4"
+          },
           "dependencies": {
             "spdx-correct": {
               "version": "1.0.2",
               "bundled": true,
+              "requires": {
+                "spdx-license-ids": "1.2.2"
+              },
               "dependencies": {
                 "spdx-license-ids": {
                   "version": "1.2.2",
@@ -5994,6 +7680,9 @@
         "validate-npm-package-name": {
           "version": "3.0.0",
           "bundled": true,
+          "requires": {
+            "builtins": "1.0.3"
+          },
           "dependencies": {
             "builtins": {
               "version": "1.0.3",
@@ -6004,6 +7693,9 @@
         "which": {
           "version": "1.2.14",
           "bundled": true,
+          "requires": {
+            "isexe": "2.0.0"
+          },
           "dependencies": {
             "isexe": {
               "version": "2.0.0",
@@ -6017,7 +7709,12 @@
         },
         "write-file-atomic": {
           "version": "2.1.0",
-          "bundled": true
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "imurmurhash": "0.1.4",
+            "slide": "1.1.6"
+          }
         }
       }
     },
@@ -6025,19 +7722,31 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-1.0.0.tgz",
       "integrity": "sha1-9cMr9ZX+ga6Sfa7FLoL4sACsPI8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "path-key": "1.0.0"
+      }
     },
     "npmlog": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
       "integrity": "sha1-3Fm+6F9k8A7UJO+yrweD3yXRwLU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "are-we-there-yet": "1.1.4",
+        "console-control-strings": "1.1.0",
+        "gauge": "2.7.4",
+        "set-blocking": "2.0.0"
+      }
     },
     "nth-check": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
       "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "boolbase": "1.0.0"
+      }
     },
     "null-check": {
       "version": "1.0.0",
@@ -6079,7 +7788,11 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "for-own": "0.1.5",
+        "is-extendable": "0.1.1"
+      }
     },
     "obuf": {
       "version": "1.1.1",
@@ -6091,7 +7804,10 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
       "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ee-first": "1.1.1"
+      }
     },
     "on-headers": {
       "version": "1.0.1",
@@ -6103,31 +7819,52 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
     },
     "onetime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "mimic-fn": "1.1.0"
+      }
     },
     "opn": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
       "integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "object-assign": "4.1.1",
+        "pinkie-promise": "2.0.1"
+      }
     },
     "optimist": {
       "version": "0.3.7",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
       "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "wordwrap": "0.0.3"
+      }
     },
     "optionator": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
+      "requires": {
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
+      },
       "dependencies": {
         "wordwrap": {
           "version": "1.0.0",
@@ -6148,12 +7885,19 @@
       "resolved": "https://registry.npmjs.org/original/-/original-1.0.0.tgz",
       "integrity": "sha1-kUf5P6FpbQS+YeAb1QuurKZWvTs=",
       "dev": true,
+      "requires": {
+        "url-parse": "1.0.5"
+      },
       "dependencies": {
         "url-parse": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.5.tgz",
           "integrity": "sha1-CFSGBCKv3P7+tsllxmLUgAFpkns=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "querystringify": "0.0.4",
+            "requires-port": "1.0.0"
+          }
         }
       }
     },
@@ -6173,7 +7917,10 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lcid": "1.0.0"
+      }
     },
     "os-tmpdir": {
       "version": "1.0.2",
@@ -6185,13 +7932,23 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
       "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
+      }
     },
     "package-json": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
       "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "got": "6.7.1",
+        "registry-auth-token": "3.3.1",
+        "registry-url": "3.1.0",
+        "semver": "5.3.0"
+      }
     },
     "pako": {
       "version": "0.2.9",
@@ -6203,48 +7960,79 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
       "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "no-case": "2.3.1"
+      }
     },
     "parse-asn1": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
       "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "asn1.js": "4.9.1",
+        "browserify-aes": "1.0.6",
+        "create-hash": "1.1.3",
+        "evp_bytestokey": "1.0.0",
+        "pbkdf2": "3.0.12"
+      }
     },
     "parse-glob": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "glob-base": "0.3.0",
+        "is-dotfile": "1.0.3",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1"
+      }
     },
     "parse-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "error-ex": "1.3.1"
+      }
     },
     "parse5": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.2.tgz",
-      "integrity": "sha1-Be/1fw70V3+xRKefi5qWemzERRA="
+      "integrity": "sha1-Be/1fw70V3+xRKefi5qWemzERRA=",
+      "requires": {
+        "@types/node": "6.0.74"
+      }
     },
     "parsejson": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.1.tgz",
       "integrity": "sha1-mxDGwNglq1ieaFFTgm3go7oni8w=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "better-assert": "1.0.2"
+      }
     },
     "parseqs": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.2.tgz",
       "integrity": "sha1-nf5wss3aw4i95PNbHyQPpYrb5sc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "better-assert": "1.0.2"
+      }
     },
     "parseuri": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.4.tgz",
       "integrity": "sha1-gGWCo5iH4eoY3V4v4OAZAiaOk1A=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "better-assert": "1.0.2"
+      }
     },
     "parseurl": {
       "version": "1.3.1",
@@ -6262,7 +8050,10 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pinkie-promise": "2.0.1"
+      }
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -6298,13 +8089,25 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
+      }
     },
     "pbkdf2": {
       "version": "3.0.12",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.12.tgz",
       "integrity": "sha1-vjZ4XFBn6kjYBv+SMojF91C2uKI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "create-hash": "1.1.3",
+        "create-hmac": "1.1.6",
+        "ripemd160": "2.0.1",
+        "safe-buffer": "5.0.1",
+        "sha.js": "2.4.8"
+      }
     },
     "performance-now": {
       "version": "0.2.0",
@@ -6328,13 +8131,21 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pinkie": "2.0.4"
+      }
     },
     "portfinder": {
       "version": "1.0.13",
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.13.tgz",
       "integrity": "sha1-uzLs2HwnEErm7kS1o8y/Drsa7ek=",
       "dev": true,
+      "requires": {
+        "async": "1.5.2",
+        "debug": "2.6.8",
+        "mkdirp": "0.5.1"
+      },
       "dependencies": {
         "async": {
           "version": "1.5.2",
@@ -6348,103 +8159,178 @@
       "version": "5.2.17",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
       "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "js-base64": "2.1.9",
+        "source-map": "0.5.6",
+        "supports-color": "3.2.3"
+      }
     },
     "postcss-calc": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
       "integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.17",
+        "postcss-message-helpers": "2.0.0",
+        "reduce-css-calc": "1.3.0"
+      }
     },
     "postcss-colormin": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.2.tgz",
       "integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "colormin": "1.1.2",
+        "postcss": "5.2.17",
+        "postcss-value-parser": "3.3.0"
+      }
     },
     "postcss-convert-values": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz",
       "integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.17",
+        "postcss-value-parser": "3.3.0"
+      }
     },
     "postcss-discard-comments": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
       "integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.17"
+      }
     },
     "postcss-discard-duplicates": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.1.0.tgz",
       "integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.17"
+      }
     },
     "postcss-discard-empty": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
       "integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.17"
+      }
     },
     "postcss-discard-overridden": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
       "integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.17"
+      }
     },
     "postcss-discard-unused": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
       "integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.17",
+        "uniqs": "2.0.0"
+      }
     },
     "postcss-filter-plugins": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.2.tgz",
       "integrity": "sha1-bYWGJTTXNaxCDkqFgG4fXUKG2Ew=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.17",
+        "uniqid": "4.1.1"
+      }
     },
     "postcss-load-config": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-1.2.0.tgz",
       "integrity": "sha1-U56a/J3chiASHr+djDZz4M5Q0oo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "cosmiconfig": "2.1.3",
+        "object-assign": "4.1.1",
+        "postcss-load-options": "1.2.0",
+        "postcss-load-plugins": "2.3.0"
+      }
     },
     "postcss-load-options": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/postcss-load-options/-/postcss-load-options-1.2.0.tgz",
       "integrity": "sha1-sJixVZ3awt8EvAuzdfmaXP4rbYw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "cosmiconfig": "2.1.3",
+        "object-assign": "4.1.1"
+      }
     },
     "postcss-load-plugins": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/postcss-load-plugins/-/postcss-load-plugins-2.3.0.tgz",
       "integrity": "sha1-dFdoEWWZrKLwCfrUJrABdQSdjZI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "cosmiconfig": "2.1.3",
+        "object-assign": "4.1.1"
+      }
     },
     "postcss-loader": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-1.3.3.tgz",
       "integrity": "sha1-piHqH6KQYqg5cqRvVEhncTAZFus=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "loader-utils": "1.1.0",
+        "object-assign": "4.1.1",
+        "postcss": "5.2.17",
+        "postcss-load-config": "1.2.0"
+      }
     },
     "postcss-merge-idents": {
       "version": "2.1.7",
       "resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
       "integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "has": "1.0.1",
+        "postcss": "5.2.17",
+        "postcss-value-parser": "3.3.0"
+      }
     },
     "postcss-merge-longhand": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.2.tgz",
       "integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.17"
+      }
     },
     "postcss-merge-rules": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz",
       "integrity": "sha1-0d9d+qexrMO+VT8OnhDofGG19yE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "browserslist": "1.7.7",
+        "caniuse-api": "1.6.1",
+        "postcss": "5.2.17",
+        "postcss-selector-parser": "2.2.3",
+        "vendors": "1.0.1"
+      }
     },
     "postcss-message-helpers": {
       "version": "2.0.0",
@@ -6456,37 +8342,66 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
       "integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "object-assign": "4.1.1",
+        "postcss": "5.2.17",
+        "postcss-value-parser": "3.3.0"
+      }
     },
     "postcss-minify-gradients": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
       "integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.17",
+        "postcss-value-parser": "3.3.0"
+      }
     },
     "postcss-minify-params": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
       "integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "alphanum-sort": "1.0.2",
+        "postcss": "5.2.17",
+        "postcss-value-parser": "3.3.0",
+        "uniqs": "2.0.0"
+      }
     },
     "postcss-minify-selectors": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
       "integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "alphanum-sort": "1.0.2",
+        "has": "1.0.1",
+        "postcss": "5.2.17",
+        "postcss-selector-parser": "2.2.3"
+      }
     },
     "postcss-modules-extract-imports": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.1.0.tgz",
       "integrity": "sha1-thTJcgvmgW6u41+zpfqh26agXds=",
       "dev": true,
+      "requires": {
+        "postcss": "6.0.1"
+      },
       "dependencies": {
         "postcss": {
           "version": "6.0.1",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.1.tgz",
           "integrity": "sha1-AA29H47vIXqjaLmiEsX8QLKo8/I=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "source-map": "0.5.6",
+            "supports-color": "3.2.3"
+          }
         }
       }
     },
@@ -6495,12 +8410,21 @@
       "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
       "integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
       "dev": true,
+      "requires": {
+        "css-selector-tokenizer": "0.7.0",
+        "postcss": "6.0.1"
+      },
       "dependencies": {
         "postcss": {
           "version": "6.0.1",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.1.tgz",
           "integrity": "sha1-AA29H47vIXqjaLmiEsX8QLKo8/I=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "source-map": "0.5.6",
+            "supports-color": "3.2.3"
+          }
         }
       }
     },
@@ -6509,12 +8433,21 @@
       "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz",
       "integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
       "dev": true,
+      "requires": {
+        "css-selector-tokenizer": "0.7.0",
+        "postcss": "6.0.1"
+      },
       "dependencies": {
         "postcss": {
           "version": "6.0.1",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.1.tgz",
           "integrity": "sha1-AA29H47vIXqjaLmiEsX8QLKo8/I=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "source-map": "0.5.6",
+            "supports-color": "3.2.3"
+          }
         }
       }
     },
@@ -6523,12 +8456,21 @@
       "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz",
       "integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
       "dev": true,
+      "requires": {
+        "icss-replace-symbols": "1.1.0",
+        "postcss": "6.0.1"
+      },
       "dependencies": {
         "postcss": {
           "version": "6.0.1",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.1.tgz",
           "integrity": "sha1-AA29H47vIXqjaLmiEsX8QLKo8/I=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "source-map": "0.5.6",
+            "supports-color": "3.2.3"
+          }
         }
       }
     },
@@ -6536,61 +8478,111 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
       "integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.17"
+      }
     },
     "postcss-normalize-url": {
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
       "integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-absolute-url": "2.1.0",
+        "normalize-url": "1.9.1",
+        "postcss": "5.2.17",
+        "postcss-value-parser": "3.3.0"
+      }
     },
     "postcss-ordered-values": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.3.tgz",
       "integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.17",
+        "postcss-value-parser": "3.3.0"
+      }
     },
     "postcss-reduce-idents": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
       "integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.17",
+        "postcss-value-parser": "3.3.0"
+      }
     },
     "postcss-reduce-initial": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
       "integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.17"
+      }
     },
     "postcss-reduce-transforms": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
       "integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "has": "1.0.1",
+        "postcss": "5.2.17",
+        "postcss-value-parser": "3.3.0"
+      }
     },
     "postcss-selector-parser": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
       "integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "flatten": "1.0.2",
+        "indexes-of": "1.0.1",
+        "uniq": "1.0.1"
+      }
     },
     "postcss-svgo": {
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
       "integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-svg": "2.1.0",
+        "postcss": "5.2.17",
+        "postcss-value-parser": "3.3.0",
+        "svgo": "0.7.2"
+      }
     },
     "postcss-unique-selectors": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
       "integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "alphanum-sort": "1.0.2",
+        "postcss": "5.2.17",
+        "uniqs": "2.0.0"
+      }
     },
     "postcss-url": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/postcss-url/-/postcss-url-5.1.2.tgz",
       "integrity": "sha1-mLMWW+jVkkccsMqt3iwNH4MvEz4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "directory-encoder": "0.7.2",
+        "js-base64": "2.1.9",
+        "mime": "1.3.6",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "path-is-absolute": "1.0.1",
+        "postcss": "5.2.17"
+      }
     },
     "postcss-value-parser": {
       "version": "3.3.0",
@@ -6602,7 +8594,12 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
       "integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "has": "1.0.1",
+        "postcss": "5.2.17",
+        "uniqs": "2.0.0"
+      }
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -6626,7 +8623,11 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.0.tgz",
       "integrity": "sha1-h/Tp1waiTIfWy+6fq+wAH8+Mddg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "renderkid": "2.0.1",
+        "utila": "0.4.0"
+      }
     },
     "process": {
       "version": "0.11.10",
@@ -6645,19 +8646,44 @@
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz",
       "integrity": "sha1-SJZUxpJha4qlWwck+oCbt9tJxb8=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "asap": "2.0.5"
+      }
     },
     "protractor": {
       "version": "4.0.9",
       "resolved": "https://registry.npmjs.org/protractor/-/protractor-4.0.9.tgz",
       "integrity": "sha1-FS9y43KbJXYibjcNwwhpnMz6d7o=",
       "dev": true,
+      "requires": {
+        "@types/jasmine": "2.5.48",
+        "@types/node": "6.0.74",
+        "@types/q": "0.0.30",
+        "@types/selenium-webdriver": "2.53.42",
+        "adm-zip": "0.4.7",
+        "chalk": "1.1.3",
+        "glob": "7.1.2",
+        "jasmine": "2.5.2",
+        "jasminewd2": "0.0.10",
+        "optimist": "0.6.1",
+        "q": "1.4.1",
+        "saucelabs": "1.3.0",
+        "selenium-webdriver": "2.53.3",
+        "source-map-support": "0.4.15",
+        "webdriver-manager": "10.2.5"
+      },
       "dependencies": {
         "jasmine": {
           "version": "2.5.2",
           "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-2.5.2.tgz",
           "integrity": "sha1-YoPO9whcCVzCXWUelU3wBPfj5CE=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "exit": "0.1.2",
+            "glob": "7.1.2",
+            "jasmine-core": "2.5.2"
+          }
         },
         "jasmine-core": {
           "version": "2.5.2",
@@ -6675,7 +8701,11 @@
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.10",
+            "wordwrap": "0.0.3"
+          }
         },
         "q": {
           "version": "1.4.1",
@@ -6689,7 +8719,11 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.4.tgz",
       "integrity": "sha1-J+VF9pYKRKYn2bREZ+NcG2tM4vM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "forwarded": "0.1.0",
+        "ipaddr.js": "1.3.0"
+      }
     },
     "prr": {
       "version": "0.0.0",
@@ -6707,7 +8741,14 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
       "integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "bn.js": "4.11.6",
+        "browserify-rsa": "4.0.1",
+        "create-hash": "1.1.3",
+        "parse-asn1": "5.1.0",
+        "randombytes": "2.0.3"
+      }
     },
     "punycode": {
       "version": "1.4.1",
@@ -6737,7 +8778,11 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
       "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "object-assign": "4.1.1",
+        "strict-uri-encode": "1.1.0"
+      }
     },
     "querystring": {
       "version": "0.2.0",
@@ -6761,7 +8806,11 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
       "integrity": "sha1-EQ3Kv/OX6dz/fAeJzMCkmt8exbs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-number": "2.1.0",
+        "kind-of": "3.2.2"
+      }
     },
     "randombytes": {
       "version": "2.0.3",
@@ -6780,6 +8829,11 @@
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.2.0.tgz",
       "integrity": "sha1-mUl2z2pQlqQRYoQEkvC9xdbn+5Y=",
       "dev": true,
+      "requires": {
+        "bytes": "2.4.0",
+        "iconv-lite": "0.4.15",
+        "unpipe": "1.0.0"
+      },
       "dependencies": {
         "bytes": {
           "version": "2.4.0",
@@ -6805,49 +8859,91 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
       "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "deep-extend": "0.4.2",
+        "ini": "1.3.4",
+        "minimist": "1.2.0",
+        "strip-json-comments": "2.0.1"
+      }
     },
     "read-pkg": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "load-json-file": "1.1.0",
+        "normalize-package-data": "2.3.8",
+        "path-type": "1.1.0"
+      }
     },
     "read-pkg-up": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "find-up": "1.1.2",
+        "read-pkg": "1.1.0"
+      }
     },
     "readable-stream": {
       "version": "2.2.9",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
       "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "buffer-shims": "1.0.0",
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "1.0.7",
+        "string_decoder": "1.0.1",
+        "util-deprecate": "1.0.2"
+      }
     },
     "readdirp": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "minimatch": "3.0.4",
+        "readable-stream": "2.2.9",
+        "set-immediate-shim": "1.0.1"
+      }
     },
     "redent": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "indent-string": "2.1.0",
+        "strip-indent": "1.0.1"
+      }
     },
     "reduce-css-calc": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
       "integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "balanced-match": "0.4.2",
+        "math-expression-evaluator": "1.2.17",
+        "reduce-function-call": "1.0.2"
+      }
     },
     "reduce-function-call": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.2.tgz",
       "integrity": "sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "balanced-match": "0.4.2"
+      }
     },
     "reflect-metadata": {
       "version": "0.1.10",
@@ -6870,25 +8966,41 @@
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
       "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-equal-shallow": "0.1.3",
+        "is-primitive": "2.0.0"
+      }
     },
     "regexpu-core": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
       "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "regenerate": "1.3.2",
+        "regjsgen": "0.2.0",
+        "regjsparser": "0.1.5"
+      }
     },
     "registry-auth-token": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.1.tgz",
       "integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "rc": "1.2.1",
+        "safe-buffer": "5.0.1"
+      }
     },
     "registry-url": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "rc": "1.2.1"
+      }
     },
     "regjsgen": {
       "version": "0.2.0",
@@ -6900,7 +9012,10 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "jsesc": "0.5.0"
+      }
     },
     "relateurl": {
       "version": "0.2.7",
@@ -6913,6 +9028,13 @@
       "resolved": "https://registry.npmjs.org/remap-istanbul/-/remap-istanbul-0.6.4.tgz",
       "integrity": "sha1-rFUe/xqmQVBLTzGNAwPdph47tpU=",
       "dev": true,
+      "requires": {
+        "amdefine": "1.0.0",
+        "gulp-util": "3.0.7",
+        "istanbul": "0.4.3",
+        "source-map": "0.5.6",
+        "through2": "2.0.1"
+      },
       "dependencies": {
         "abbrev": {
           "version": "1.0.9",
@@ -6945,6 +9067,11 @@
           "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
           "dev": true,
           "optional": true,
+          "requires": {
+            "center-align": "0.1.3",
+            "right-align": "0.1.3",
+            "wordwrap": "0.0.2"
+          },
           "dependencies": {
             "wordwrap": {
               "version": "0.0.2",
@@ -6960,12 +9087,21 @@
           "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
           "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
           "dev": true,
+          "requires": {
+            "async": "1.5.2",
+            "optimist": "0.6.1",
+            "source-map": "0.4.4",
+            "uglify-js": "2.8.27"
+          },
           "dependencies": {
             "source-map": {
               "version": "0.4.4",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
               "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "amdefine": "1.0.0"
+              }
             }
           }
         },
@@ -6973,7 +9109,23 @@
           "version": "0.4.3",
           "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.3.tgz",
           "integrity": "sha1-W3FO4K5JOsXvIEuZ84crzu9z1To=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "abbrev": "1.0.9",
+            "async": "1.5.2",
+            "escodegen": "1.8.1",
+            "esprima": "2.7.3",
+            "fileset": "0.2.1",
+            "handlebars": "4.0.10",
+            "js-yaml": "3.7.0",
+            "mkdirp": "0.5.1",
+            "nopt": "3.0.6",
+            "once": "1.4.0",
+            "resolve": "1.1.7",
+            "supports-color": "3.2.3",
+            "which": "1.2.14",
+            "wordwrap": "1.0.0"
+          }
         },
         "minimist": {
           "version": "0.0.10",
@@ -6985,13 +9137,20 @@
           "version": "3.0.6",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
           "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "abbrev": "1.0.9"
+          }
         },
         "optimist": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
           "dev": true,
+          "requires": {
+            "minimist": "0.0.10",
+            "wordwrap": "0.0.3"
+          },
           "dependencies": {
             "wordwrap": {
               "version": "0.0.3",
@@ -7012,7 +9171,12 @@
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.27.tgz",
           "integrity": "sha1-R3h/kSsPJC5bmENDvo416V9pTJw=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "source-map": "0.5.6",
+            "uglify-to-browserify": "1.0.2",
+            "yargs": "3.10.0"
+          }
         },
         "wordwrap": {
           "version": "1.0.0",
@@ -7025,7 +9189,13 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "camelcase": "1.2.1",
+            "cliui": "2.1.0",
+            "decamelize": "1.2.0",
+            "window-size": "0.1.0"
+          }
         }
       }
     },
@@ -7040,6 +9210,13 @@
       "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.1.tgz",
       "integrity": "sha1-iYyr/Ivt5Le5ETWj/9Mj5YwNsxk=",
       "dev": true,
+      "requires": {
+        "css-select": "1.2.0",
+        "dom-converter": "0.1.4",
+        "htmlparser2": "3.3.0",
+        "strip-ansi": "3.0.1",
+        "utila": "0.3.3"
+      },
       "dependencies": {
         "utila": {
           "version": "0.3.3",
@@ -7065,7 +9242,10 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-finite": "1.0.2"
+      }
     },
     "replace-ext": {
       "version": "0.0.1",
@@ -7077,7 +9257,31 @@
       "version": "2.81.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
       "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "aws-sign2": "0.6.0",
+        "aws4": "1.6.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.5",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.1.4",
+        "har-validator": "4.2.1",
+        "hawk": "3.1.3",
+        "http-signature": "1.1.1",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.15",
+        "oauth-sign": "0.8.2",
+        "performance-now": "0.2.0",
+        "qs": "6.4.0",
+        "safe-buffer": "5.0.1",
+        "stringstream": "0.0.5",
+        "tough-cookie": "2.3.2",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.0.1"
+      }
     },
     "require-directory": {
       "version": "2.1.1",
@@ -7107,31 +9311,48 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
       "integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "path-parse": "1.0.5"
+      }
     },
     "restore-cursor": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "onetime": "2.0.1",
+        "signal-exit": "3.0.2"
+      }
     },
     "right-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "align-text": "0.1.4"
+      }
     },
     "rimraf": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
       "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2"
+      }
     },
     "ripemd160": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
       "integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "hash-base": "2.0.2",
+        "inherits": "2.0.3"
+      }
     },
     "rsvp": {
       "version": "3.5.0",
@@ -7143,7 +9364,10 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-promise": "2.1.0"
+      }
     },
     "rx": {
       "version": "4.1.0",
@@ -7154,7 +9378,10 @@
     "rxjs": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.4.0.tgz",
-      "integrity": "sha1-p9sUqxV/nXqsalbmVeejhg05vyY="
+      "integrity": "sha1-p9sUqxV/nXqsalbmVeejhg05vyY=",
+      "requires": {
+        "symbol-observable": "1.0.4"
+      }
     },
     "safe-buffer": {
       "version": "5.0.1",
@@ -7166,19 +9393,35 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
       "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2",
+        "lodash": "4.17.4",
+        "scss-tokenizer": "0.2.3",
+        "yargs": "7.1.0"
+      }
     },
     "sass-loader": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-6.0.5.tgz",
       "integrity": "sha1-qEeRDzZEKqVsWYWHnVTrUZ4koyg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "async": "2.4.1",
+        "clone-deep": "0.2.4",
+        "loader-utils": "1.1.0",
+        "lodash.tail": "4.1.1",
+        "pify": "2.3.0"
+      }
     },
     "saucelabs": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/saucelabs/-/saucelabs-1.3.0.tgz",
       "integrity": "sha1-0kDoAJ33+ocwbsRXimm6O1xCT+4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "https-proxy-agent": "1.0.0"
+      }
     },
     "sax": {
       "version": "1.2.2",
@@ -7190,19 +9433,29 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/script-loader/-/script-loader-0.7.0.tgz",
       "integrity": "sha1-aF3H5waeDe56kmdPDrxbD1W6pew=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "raw-loader": "0.5.1"
+      }
     },
     "scss-tokenizer": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
       "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
       "dev": true,
+      "requires": {
+        "js-base64": "2.1.9",
+        "source-map": "0.4.4"
+      },
       "dependencies": {
         "source-map": {
           "version": "0.4.4",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
         }
       }
     },
@@ -7217,6 +9470,13 @@
       "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-2.53.3.tgz",
       "integrity": "sha1-0p/1qVff8aG0ncRXdW5OS/vc4IU=",
       "dev": true,
+      "requires": {
+        "adm-zip": "0.4.4",
+        "rimraf": "2.6.1",
+        "tmp": "0.0.24",
+        "ws": "1.0.1",
+        "xml2js": "0.4.4"
+      },
       "dependencies": {
         "adm-zip": {
           "version": "0.4.4",
@@ -7242,25 +9502,49 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
       "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "semver": "5.3.0"
+      }
     },
     "semver-dsl": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/semver-dsl/-/semver-dsl-1.0.1.tgz",
       "integrity": "sha1-02eN5VVeimH2Ke7QJTZq5fJzQKA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "semver": "5.3.0"
+      }
     },
     "send": {
       "version": "0.15.3",
       "resolved": "https://registry.npmjs.org/send/-/send-0.15.3.tgz",
       "integrity": "sha1-UBP5+ZAj31DRvZiSwZ4979HVMwk=",
       "dev": true,
+      "requires": {
+        "debug": "2.6.7",
+        "depd": "1.1.0",
+        "destroy": "1.0.4",
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
+        "etag": "1.8.0",
+        "fresh": "0.5.0",
+        "http-errors": "1.6.1",
+        "mime": "1.3.4",
+        "ms": "2.0.0",
+        "on-finished": "2.3.0",
+        "range-parser": "1.2.0",
+        "statuses": "1.3.1"
+      },
       "dependencies": {
         "debug": {
           "version": "2.6.7",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
           "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
         },
         "mime": {
           "version": "1.3.4",
@@ -7274,13 +9558,28 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.0.tgz",
       "integrity": "sha1-0rKA/FYNYW7oG0i/D6gqvtJIXOc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "accepts": "1.3.3",
+        "batch": "0.6.1",
+        "debug": "2.6.8",
+        "escape-html": "1.0.3",
+        "http-errors": "1.6.1",
+        "mime-types": "2.1.15",
+        "parseurl": "1.3.1"
+      }
     },
     "serve-static": {
       "version": "1.12.3",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.3.tgz",
       "integrity": "sha1-n0uhni8wMMVH+K+ZEHg47DjVseI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
+        "parseurl": "1.3.1",
+        "send": "0.15.3"
+      }
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -7310,19 +9609,31 @@
       "version": "2.4.8",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz",
       "integrity": "sha1-NwaMLEdra69ALRSknGf1l5IfY08=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3"
+      }
     },
     "shallow-clone": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-0.1.2.tgz",
       "integrity": "sha1-WQnodLp3EG1zrEFM/sH/yofZcGA=",
       "dev": true,
+      "requires": {
+        "is-extendable": "0.1.1",
+        "kind-of": "2.0.1",
+        "lazy-cache": "0.2.7",
+        "mixin-object": "2.0.1"
+      },
       "dependencies": {
         "kind-of": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
           "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.5"
+          }
         },
         "lazy-cache": {
           "version": "0.2.7",
@@ -7342,7 +9653,10 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/silent-error/-/silent-error-1.1.0.tgz",
       "integrity": "sha1-IglwbxyFCp8dENDYQJGLRvJuG8k=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "debug": "2.6.8"
+      }
     },
     "slide": {
       "version": "1.1.6",
@@ -7354,19 +9668,33 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "hoek": "2.16.3"
+      }
     },
     "socket.io": {
       "version": "1.4.7",
       "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.4.7.tgz",
       "integrity": "sha1-krf3y4jFeX1NruJ5/oB12+bT+hw=",
       "dev": true,
+      "requires": {
+        "debug": "2.2.0",
+        "engine.io": "1.6.10",
+        "has-binary": "0.1.7",
+        "socket.io-adapter": "0.4.0",
+        "socket.io-client": "1.4.6",
+        "socket.io-parser": "2.2.6"
+      },
       "dependencies": {
         "debug": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "0.7.1"
+          }
         },
         "ms": {
           "version": "0.7.1",
@@ -7381,12 +9709,19 @@
       "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.4.0.tgz",
       "integrity": "sha1-+5+CqxqmUpC/csNleVW5MKmRok8=",
       "dev": true,
+      "requires": {
+        "debug": "2.2.0",
+        "socket.io-parser": "2.2.2"
+      },
       "dependencies": {
         "debug": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "0.7.1"
+          }
         },
         "isarray": {
           "version": "0.0.1",
@@ -7411,6 +9746,13 @@
           "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.2.tgz",
           "integrity": "sha1-PXr2tkSX6Va32f53X5mXFgJ/lBc=",
           "dev": true,
+          "requires": {
+            "benchmark": "1.0.0",
+            "component-emitter": "1.1.2",
+            "debug": "0.7.4",
+            "isarray": "0.0.1",
+            "json3": "3.2.6"
+          },
           "dependencies": {
             "debug": {
               "version": "0.7.4",
@@ -7427,6 +9769,19 @@
       "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.4.6.tgz",
       "integrity": "sha1-SbC6U379FbgpfIQBbmQuHHx1LD0=",
       "dev": true,
+      "requires": {
+        "backo2": "1.0.2",
+        "component-bind": "1.0.0",
+        "component-emitter": "1.2.0",
+        "debug": "2.2.0",
+        "engine.io-client": "1.6.9",
+        "has-binary": "0.1.7",
+        "indexof": "0.0.1",
+        "object-component": "0.0.3",
+        "parseuri": "0.0.4",
+        "socket.io-parser": "2.2.6",
+        "to-array": "0.1.4"
+      },
       "dependencies": {
         "component-emitter": {
           "version": "1.2.0",
@@ -7438,7 +9793,10 @@
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "0.7.1"
+          }
         },
         "ms": {
           "version": "0.7.1",
@@ -7453,12 +9811,22 @@
       "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.6.tgz",
       "integrity": "sha1-ON/WHfUNz4qx2eIJEyK/kCuii5k=",
       "dev": true,
+      "requires": {
+        "benchmark": "1.0.0",
+        "component-emitter": "1.1.2",
+        "debug": "2.2.0",
+        "isarray": "0.0.1",
+        "json3": "3.3.2"
+      },
       "dependencies": {
         "debug": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "0.7.1"
+          }
         },
         "isarray": {
           "version": "0.0.1",
@@ -7479,6 +9847,10 @@
       "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.18.tgz",
       "integrity": "sha1-2bKJMWyn33dZXvKZ4HXw+TfrQgc=",
       "dev": true,
+      "requires": {
+        "faye-websocket": "0.10.0",
+        "uuid": "2.0.3"
+      },
       "dependencies": {
         "uuid": {
           "version": "2.0.3",
@@ -7493,12 +9865,23 @@
       "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.2.tgz",
       "integrity": "sha1-8CEqhVDkyUaMjM6u79LjSTwDOtU=",
       "dev": true,
+      "requires": {
+        "debug": "2.6.8",
+        "eventsource": "0.1.6",
+        "faye-websocket": "0.11.1",
+        "inherits": "2.0.3",
+        "json3": "3.3.2",
+        "url-parse": "1.1.9"
+      },
       "dependencies": {
         "faye-websocket": {
           "version": "0.11.1",
           "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
           "integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "websocket-driver": "0.6.5"
+          }
         }
       }
     },
@@ -7506,7 +9889,10 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
       "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-plain-obj": "1.1.0"
+      }
     },
     "source-list-map": {
       "version": "0.1.8",
@@ -7524,6 +9910,11 @@
       "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-0.2.1.tgz",
       "integrity": "sha1-SBJr6SML1H+tBeRqjDwuPS2r5Qc=",
       "dev": true,
+      "requires": {
+        "async": "0.9.2",
+        "loader-utils": "0.2.17",
+        "source-map": "0.1.43"
+      },
       "dependencies": {
         "async": {
           "version": "0.9.2",
@@ -7535,20 +9926,32 @@
           "version": "0.2.17",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
           "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "big.js": "3.1.3",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1",
+            "object-assign": "4.1.1"
+          }
         },
         "source-map": {
           "version": "0.1.43",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
           "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
         }
       }
     },
     "source-map-support": {
       "version": "0.4.15",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz",
-      "integrity": "sha1-AyAt9lwG0r2MfsI2KhkwVv7407E="
+      "integrity": "sha1-AyAt9lwG0r2MfsI2KhkwVv7407E=",
+      "requires": {
+        "source-map": "0.5.6"
+      }
     },
     "sparkles": {
       "version": "1.0.0",
@@ -7560,7 +9963,10 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "spdx-license-ids": "1.2.2"
+      }
     },
     "spdx-expression-parse": {
       "version": "1.0.4",
@@ -7578,13 +9984,30 @@
       "version": "3.4.7",
       "resolved": "https://registry.npmjs.org/spdy/-/spdy-3.4.7.tgz",
       "integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "debug": "2.6.8",
+        "handle-thing": "1.2.5",
+        "http-deceiver": "1.2.7",
+        "safe-buffer": "5.0.1",
+        "select-hose": "2.0.0",
+        "spdy-transport": "2.0.20"
+      }
     },
     "spdy-transport": {
       "version": "2.0.20",
       "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.20.tgz",
       "integrity": "sha1-c15yBUxIayNU/onnAiVgBKOazk0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "debug": "2.6.8",
+        "detect-node": "2.0.3",
+        "hpack.js": "2.1.6",
+        "obuf": "1.1.1",
+        "readable-stream": "2.2.9",
+        "safe-buffer": "5.0.1",
+        "wbuf": "1.7.2"
+      }
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -7597,6 +10020,17 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
       "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
       "dev": true,
+      "requires": {
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jodid25519": "1.0.2",
+        "jsbn": "0.1.1",
+        "tweetnacl": "0.14.5"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -7616,19 +10050,33 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.0.tgz",
       "integrity": "sha1-osfIWH5U2UJ+qe2zrD8s1SLfN4s=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "readable-stream": "2.2.9"
+      }
     },
     "stream-browserify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
       "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.2.9"
+      }
     },
     "stream-http": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.1.tgz",
       "integrity": "sha1-VGpRdBrVprB+njGwsQRBqRffUoo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "builtin-status-codes": "3.0.0",
+        "inherits": "2.0.3",
+        "readable-stream": "2.2.9",
+        "to-arraybuffer": "1.0.1",
+        "xtend": "4.0.1"
+      }
     },
     "strict-uri-encode": {
       "version": "1.1.0",
@@ -7636,17 +10084,24 @@
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
-      "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
-      "dev": true
-    },
     "string-width": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
       "integrity": "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "2.0.0",
+        "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+      "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.0.1"
+      }
     },
     "stringstream": {
       "version": "0.0.5",
@@ -7658,13 +10113,19 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
     },
     "strip-bom": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-utf8": "0.2.1"
+      }
     },
     "strip-eof": {
       "version": "1.0.0",
@@ -7676,7 +10137,10 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "get-stdin": "4.0.1"
+      }
     },
     "strip-json-comments": {
       "version": "2.0.1",
@@ -7688,19 +10152,38 @@
       "version": "0.13.2",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.13.2.tgz",
       "integrity": "sha1-dFMzhM9pjHEEx5URULSXF63C87s=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "loader-utils": "1.1.0"
+      }
     },
     "stylus": {
       "version": "0.54.5",
       "resolved": "https://registry.npmjs.org/stylus/-/stylus-0.54.5.tgz",
       "integrity": "sha1-QrlWCTHKcJDOhRWnmLqeaqPW3Hk=",
       "dev": true,
+      "requires": {
+        "css-parse": "1.7.0",
+        "debug": "2.6.8",
+        "glob": "7.0.6",
+        "mkdirp": "0.5.1",
+        "sax": "0.5.8",
+        "source-map": "0.1.43"
+      },
       "dependencies": {
         "glob": {
           "version": "7.0.6",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
           "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
         },
         "sax": {
           "version": "0.5.8",
@@ -7712,7 +10195,10 @@
           "version": "0.1.43",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
           "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
         }
       }
     },
@@ -7720,19 +10206,36 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/stylus-loader/-/stylus-loader-3.0.1.tgz",
       "integrity": "sha1-d/SzT9Aw0lsmF7z1UT21sHMMQIk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "loader-utils": "1.1.0",
+        "lodash.clonedeep": "4.5.0",
+        "when": "3.6.4"
+      }
     },
     "supports-color": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
       "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "has-flag": "1.0.0"
+      }
     },
     "svgo": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz",
       "integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "coa": "1.0.2",
+        "colors": "1.1.2",
+        "csso": "2.3.2",
+        "js-yaml": "3.7.0",
+        "mkdirp": "0.5.1",
+        "sax": "1.2.2",
+        "whet.extend": "0.9.9"
+      }
     },
     "symbol-observable": {
       "version": "1.0.4",
@@ -7749,13 +10252,22 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
       "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "block-stream": "0.0.9",
+        "fstream": "1.0.11",
+        "inherits": "2.0.3"
+      }
     },
     "temp": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
       "integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
       "dev": true,
+      "requires": {
+        "os-tmpdir": "1.0.2",
+        "rimraf": "2.2.8"
+      },
       "dependencies": {
         "rimraf": {
           "version": "2.2.8",
@@ -7769,7 +10281,10 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-0.1.1.tgz",
       "integrity": "sha1-hzYLljlsq1dgljcUzaDQy+7K2co=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "execa": "0.4.0"
+      }
     },
     "through": {
       "version": "2.3.8",
@@ -7782,12 +10297,24 @@
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
       "integrity": "sha1-OE51MU1J8y3hLuu4E2uOtrXVnak=",
       "dev": true,
+      "requires": {
+        "readable-stream": "2.0.6",
+        "xtend": "4.0.1"
+      },
       "dependencies": {
         "readable-stream": {
           "version": "2.0.6",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
           "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "0.10.31",
+            "util-deprecate": "1.0.2"
+          }
         },
         "string_decoder": {
           "version": "0.10.31",
@@ -7813,13 +10340,19 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.2.tgz",
       "integrity": "sha1-q0iDz1l9zVCvIRNJoA+8pWrIa4Y=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "setimmediate": "1.0.5"
+      }
     },
     "tmp": {
       "version": "0.0.31",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
       "integrity": "sha1-jzirlDjhcxXl29izZX6L+yd65Kc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "1.0.2"
+      }
     },
     "to-array": {
       "version": "0.1.4",
@@ -7849,7 +10382,10 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
       "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "punycode": "1.4.1"
+      }
     },
     "trim-newlines": {
       "version": "1.0.0",
@@ -7873,6 +10409,18 @@
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-1.2.1.tgz",
       "integrity": "sha1-EI8eQzZuJfUiPoVJ+nxtz3gO2iM=",
       "dev": true,
+      "requires": {
+        "arrify": "1.0.1",
+        "chalk": "1.1.3",
+        "diff": "2.2.3",
+        "make-error": "1.3.0",
+        "minimist": "1.2.0",
+        "mkdirp": "0.5.1",
+        "pinkie": "2.0.4",
+        "source-map-support": "0.4.15",
+        "tsconfig": "5.0.3",
+        "xtend": "4.0.1"
+      },
       "dependencies": {
         "diff": {
           "version": "2.2.3",
@@ -7886,18 +10434,41 @@
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-5.0.3.tgz",
       "integrity": "sha1-X0J45wGACWeo/Dg/0ZZIh48qbjo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "any-promise": "1.3.0",
+        "parse-json": "2.2.0",
+        "strip-bom": "2.0.0",
+        "strip-json-comments": "2.0.1"
+      }
     },
     "tsickle": {
       "version": "0.21.6",
       "resolved": "https://registry.npmjs.org/tsickle/-/tsickle-0.21.6.tgz",
-      "integrity": "sha1-U7Abl5xcE/2xOvs/uVgXflmRWI0="
+      "integrity": "sha1-U7Abl5xcE/2xOvs/uVgXflmRWI0=",
+      "requires": {
+        "minimist": "1.2.0",
+        "mkdirp": "0.5.1",
+        "source-map": "0.5.6",
+        "source-map-support": "0.4.15"
+      }
     },
     "tslint": {
       "version": "4.5.1",
       "resolved": "https://registry.npmjs.org/tslint/-/tslint-4.5.1.tgz",
       "integrity": "sha1-BTVocb7yOkNJBnNABvwYgza6gks=",
       "dev": true,
+      "requires": {
+        "babel-code-frame": "6.22.0",
+        "colors": "1.1.2",
+        "diff": "3.2.0",
+        "findup-sync": "0.3.0",
+        "glob": "7.1.2",
+        "optimist": "0.6.1",
+        "resolve": "1.3.3",
+        "tsutils": "1.9.1",
+        "update-notifier": "2.1.0"
+      },
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
@@ -7909,7 +10480,11 @@
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.10",
+            "wordwrap": "0.0.3"
+          }
         }
       }
     },
@@ -7929,7 +10504,10 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.0.1"
+      }
     },
     "tweetnacl": {
       "version": "0.14.5",
@@ -7942,13 +10520,20 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2"
+      }
     },
     "type-is": {
       "version": "1.6.15",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
       "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "2.1.15"
+      }
     },
     "typescript": {
       "version": "2.3.4",
@@ -7960,7 +10545,11 @@
       "version": "3.0.14",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.0.14.tgz",
       "integrity": "sha1-JpevEm/SFarFVvrLHt+xeHUgR2A=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "commander": "2.9.0",
+        "source-map": "0.5.6"
+      }
     },
     "uglify-to-browserify": {
       "version": "1.0.2",
@@ -7985,7 +10574,10 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/uniqid/-/uniqid-4.1.1.tgz",
       "integrity": "sha1-iSIN32t1GuUrX3JISGNShZa7hME=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "macaddress": "0.2.8"
+      }
     },
     "uniqs": {
       "version": "2.0.0",
@@ -7997,7 +10589,10 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
       "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "crypto-random-string": "1.0.0"
+      }
     },
     "unpipe": {
       "version": "1.0.0",
@@ -8015,7 +10610,17 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.1.0.tgz",
       "integrity": "sha1-7AweU1NrdmR6JLd8uDlm2TFRI9k=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "boxen": "1.1.0",
+        "chalk": "1.1.3",
+        "configstore": "3.1.0",
+        "is-npm": "1.0.0",
+        "latest-version": "3.1.0",
+        "lazy-req": "2.0.0",
+        "semver-diff": "2.1.0",
+        "xdg-basedir": "3.0.0"
+      }
     },
     "upper-case": {
       "version": "1.1.3",
@@ -8028,6 +10633,10 @@
       "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
       "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
       "dev": true,
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      },
       "dependencies": {
         "punycode": {
           "version": "1.3.2",
@@ -8041,13 +10650,21 @@
       "version": "0.5.8",
       "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-0.5.8.tgz",
       "integrity": "sha1-uRg7GAHg+EdxhnNnMEC8ncHHFcU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "loader-utils": "1.1.0",
+        "mime": "1.3.6"
+      }
     },
     "url-parse": {
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.9.tgz",
       "integrity": "sha1-xn8dd11R8KGJEd17P/rSe7nlvRk=",
       "dev": true,
+      "requires": {
+        "querystringify": "1.0.0",
+        "requires-port": "1.0.0"
+      },
       "dependencies": {
         "querystringify": {
           "version": "1.0.0",
@@ -8061,13 +10678,20 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
       "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "prepend-http": "1.0.4"
+      }
     },
     "useragent": {
       "version": "2.1.13",
       "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.1.13.tgz",
       "integrity": "sha1-u6Q+iqJNXOuDwpN0c+EC4h33TBA=",
       "dev": true,
+      "requires": {
+        "lru-cache": "2.2.4",
+        "tmp": "0.0.31"
+      },
       "dependencies": {
         "lru-cache": {
           "version": "2.2.4",
@@ -8088,6 +10712,9 @@
       "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
       "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
       "dev": true,
+      "requires": {
+        "inherits": "2.0.1"
+      },
       "dependencies": {
         "inherits": {
           "version": "2.0.1",
@@ -8125,7 +10752,11 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "spdx-correct": "1.0.2",
+        "spdx-expression-parse": "1.0.4"
+      }
     },
     "vary": {
       "version": "1.1.1",
@@ -8143,13 +10774,21 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
       "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "extsprintf": "1.0.2"
+      }
     },
     "vinyl": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
       "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "clone": "1.0.2",
+        "clone-stats": "0.0.1",
+        "replace-ext": "0.0.1"
+      }
     },
     "vlq": {
       "version": "0.2.2",
@@ -8161,7 +10800,10 @@
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
       "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "indexof": "0.0.1"
+      }
     },
     "void-elements": {
       "version": "2.0.1",
@@ -8173,31 +10815,78 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.3.2.tgz",
       "integrity": "sha1-SCcoCvxC0OA1NnxKTjHurA0Tb3U=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ensure-posix-path": "1.0.2",
+        "matcher-collection": "1.0.4"
+      }
     },
     "watchpack": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.3.1.tgz",
       "integrity": "sha1-fYaTkHsozmAT5/NhCqKhrPB9rYc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "async": "2.4.1",
+        "chokidar": "1.7.0",
+        "graceful-fs": "4.1.11"
+      }
     },
     "wbuf": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.2.tgz",
       "integrity": "sha1-1pe5nx9ZUS3ydRvkJ2nBWAtYAf4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "minimalistic-assert": "1.0.0"
+      }
     },
     "webdriver-manager": {
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/webdriver-manager/-/webdriver-manager-10.2.5.tgz",
       "integrity": "sha1-ZDPBpksDg4jCle0NydqnHl31Ak4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "adm-zip": "0.4.7",
+        "chalk": "1.1.3",
+        "del": "2.2.2",
+        "glob": "7.1.2",
+        "ini": "1.3.4",
+        "minimist": "1.2.0",
+        "q": "1.5.0",
+        "request": "2.81.0",
+        "rimraf": "2.6.1",
+        "semver": "5.3.0"
+      }
     },
     "webpack": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-2.4.1.tgz",
       "integrity": "sha1-FakdvjSWbYpLmcfWVu/ZKi5ab2o=",
       "dev": true,
+      "requires": {
+        "acorn": "5.0.3",
+        "acorn-dynamic-import": "2.0.2",
+        "ajv": "4.11.8",
+        "ajv-keywords": "1.5.1",
+        "async": "2.4.1",
+        "enhanced-resolve": "3.1.0",
+        "interpret": "1.0.3",
+        "json-loader": "0.5.4",
+        "json5": "0.5.1",
+        "loader-runner": "2.3.0",
+        "loader-utils": "0.2.17",
+        "memory-fs": "0.4.1",
+        "mkdirp": "0.5.1",
+        "node-libs-browser": "2.0.0",
+        "source-map": "0.5.6",
+        "supports-color": "3.2.3",
+        "tapable": "0.2.6",
+        "uglify-js": "2.8.27",
+        "watchpack": "1.3.1",
+        "webpack-sources": "0.2.3",
+        "yargs": "6.6.0"
+      },
       "dependencies": {
         "camelcase": {
           "version": "1.2.1",
@@ -8209,19 +10898,33 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
           "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "center-align": "0.1.3",
+            "right-align": "0.1.3",
+            "wordwrap": "0.0.2"
+          }
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
         },
         "loader-utils": {
           "version": "0.2.17",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
           "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "big.js": "3.1.3",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1",
+            "object-assign": "4.1.1"
+          }
         },
         "source-list-map": {
           "version": "1.1.2",
@@ -8233,19 +10936,35 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
         },
         "uglify-js": {
           "version": "2.8.27",
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.27.tgz",
           "integrity": "sha1-R3h/kSsPJC5bmENDvo416V9pTJw=",
           "dev": true,
+          "requires": {
+            "source-map": "0.5.6",
+            "uglify-to-browserify": "1.0.2",
+            "yargs": "3.10.0"
+          },
           "dependencies": {
             "yargs": {
               "version": "3.10.0",
               "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
               "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "camelcase": "1.2.1",
+                "cliui": "2.1.0",
+                "decamelize": "1.2.0",
+                "window-size": "0.1.0"
+              }
             }
           }
         },
@@ -8253,7 +10972,11 @@
           "version": "0.2.3",
           "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-0.2.3.tgz",
           "integrity": "sha1-F8Yr+vE8cH+dAsR54Nzd6DgGl/s=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "source-list-map": "1.1.2",
+            "source-map": "0.5.6"
+          }
         },
         "wordwrap": {
           "version": "0.0.2",
@@ -8266,6 +10989,21 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
           "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
           "dev": true,
+          "requires": {
+            "camelcase": "3.0.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "1.4.0",
+            "read-pkg-up": "1.0.1",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "1.0.2",
+            "which-module": "1.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "4.2.1"
+          },
           "dependencies": {
             "camelcase": {
               "version": "3.0.0",
@@ -8277,7 +11015,12 @@
               "version": "3.2.0",
               "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
               "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1",
+                "wrap-ansi": "2.1.0"
+              }
             }
           }
         },
@@ -8286,6 +11029,9 @@
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
           "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
           "dev": true,
+          "requires": {
+            "camelcase": "3.0.0"
+          },
           "dependencies": {
             "camelcase": {
               "version": "3.0.0",
@@ -8301,13 +11047,38 @@
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.10.2.tgz",
       "integrity": "sha1-LiUs4d+wINvaHMs33ybzCrAU29E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "memory-fs": "0.4.1",
+        "mime": "1.3.6",
+        "path-is-absolute": "1.0.1",
+        "range-parser": "1.2.0"
+      }
     },
     "webpack-dev-server": {
       "version": "2.4.5",
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.4.5.tgz",
       "integrity": "sha1-MThM6BE2vhCAtLTN4OubkOVO5s8=",
       "dev": true,
+      "requires": {
+        "ansi-html": "0.0.7",
+        "chokidar": "1.7.0",
+        "compression": "1.6.2",
+        "connect-history-api-fallback": "1.3.0",
+        "express": "4.15.3",
+        "html-entities": "1.2.1",
+        "http-proxy-middleware": "0.17.4",
+        "opn": "4.0.2",
+        "portfinder": "1.0.13",
+        "serve-index": "1.9.0",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.2",
+        "spdy": "3.4.7",
+        "strip-ansi": "3.0.1",
+        "supports-color": "3.2.3",
+        "webpack-dev-middleware": "1.10.2",
+        "yargs": "6.6.0"
+      },
       "dependencies": {
         "camelcase": {
           "version": "3.0.0",
@@ -8319,25 +11090,51 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
         },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
         },
         "yargs": {
           "version": "6.6.0",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
           "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "camelcase": "3.0.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "1.4.0",
+            "read-pkg-up": "1.0.1",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "1.0.2",
+            "which-module": "1.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "4.2.1"
+          }
         },
         "yargs-parser": {
           "version": "4.2.1",
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
           "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "camelcase": "3.0.0"
+          }
         }
       }
     },
@@ -8345,19 +11142,29 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-2.6.1.tgz",
       "integrity": "sha1-8dgB0sXTn4P/7J8RkkCz476ZShw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.4"
+      }
     },
     "webpack-sources": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-0.1.5.tgz",
       "integrity": "sha1-qh86vw8NdNtxEcQOUAuE+WZkB1A=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "source-list-map": "0.1.8",
+        "source-map": "0.5.6"
+      }
     },
     "websocket-driver": {
       "version": "0.6.5",
       "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz",
       "integrity": "sha1-XLJVbOuF9Dc8bYI4qmkchFThOjY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "websocket-extensions": "0.1.1"
+      }
     },
     "websocket-extensions": {
       "version": "0.1.1",
@@ -8381,7 +11188,10 @@
       "version": "1.2.14",
       "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
       "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "isexe": "2.0.0"
+      }
     },
     "which-module": {
       "version": "1.0.0",
@@ -8394,18 +11204,29 @@
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
       "integrity": "sha1-Vx4PGwYEY268DfwhsDObvjE0FxA=",
       "dev": true,
+      "requires": {
+        "string-width": "1.0.2"
+      },
       "dependencies": {
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
         },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
         }
       }
     },
@@ -8414,18 +11235,29 @@
       "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
       "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
       "dev": true,
+      "requires": {
+        "string-width": "1.0.2"
+      },
       "dependencies": {
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
         },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
         }
       }
     },
@@ -8446,18 +11278,30 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
+      "requires": {
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1"
+      },
       "dependencies": {
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
         },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
         }
       }
     },
@@ -8471,13 +11315,22 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.1.0.tgz",
       "integrity": "sha1-F2n0tVHu3OQZ8FBd6uLiZ2NULTc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "imurmurhash": "0.1.4",
+        "slide": "1.1.6"
+      }
     },
     "ws": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-1.0.1.tgz",
       "integrity": "sha1-fQsqLljN3YGQOcKcneZQReGzEOk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "options": "0.0.6",
+        "ultron": "1.0.2"
+      }
     },
     "xdg-basedir": {
       "version": "3.0.0",
@@ -8501,6 +11354,10 @@
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.4.tgz",
       "integrity": "sha1-MREBAAMAiuGSQOuhdJe1fHKcVV0=",
       "dev": true,
+      "requires": {
+        "sax": "0.6.1",
+        "xmlbuilder": "9.0.0"
+      },
       "dependencies": {
         "sax": {
           "version": "0.6.1",
@@ -8551,6 +11408,21 @@
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
       "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
       "dev": true,
+      "requires": {
+        "camelcase": "3.0.0",
+        "cliui": "3.2.0",
+        "decamelize": "1.2.0",
+        "get-caller-file": "1.0.2",
+        "os-locale": "1.4.0",
+        "read-pkg-up": "1.0.1",
+        "require-directory": "2.1.1",
+        "require-main-filename": "1.0.1",
+        "set-blocking": "2.0.0",
+        "string-width": "1.0.2",
+        "which-module": "1.0.0",
+        "y18n": "3.2.1",
+        "yargs-parser": "5.0.0"
+      },
       "dependencies": {
         "camelcase": {
           "version": "3.0.0",
@@ -8562,13 +11434,21 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
         },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
         }
       }
     },
@@ -8577,6 +11457,9 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
       "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
       "dev": true,
+      "requires": {
+        "camelcase": "3.0.0"
+      },
       "dependencies": {
         "camelcase": {
           "version": "3.0.0",


### PR DESCRIPTION
This addresses a security vulnerability in `handlebars` < 4.0.0 by updating the dependency tree (using
npm 5.4.2) to instead declare 4.0.10 in `package-lock.json`.